### PR TITLE
Fix duplicate slug route and clean up lint warnings

### DIFF
--- a/change_log.json
+++ b/change_log.json
@@ -146,4 +146,65 @@
   "b1e2e2e0-6c7e-4e7e-9e2e-1a2b3c4d5e6f": {
     "src/app/posts/_components/PostCard.tsx": "Migrated full PostCard implementation from old molecules, replaced useTransition with manual isPending state, added fallback HeartIcon inline SVG, and fixed linter errors for type arguments."
   }
+,
+  "199f5f24-109a-4977-bd2e-1ebce12d1c4a": {
+    "src/app/dashboard/collectives/_components/DashboardCollectiveCard.tsx": "Add missing icon imports and correct useRouter import"
+  },
+  "409b069c-6e39-4341-a062-f9a9fa614e91": {
+    "src/app/posts/_components/PostReactionButtons.tsx": "Remove stray characters causing syntax error"
+  },
+  "fb58684d-209c-4e6b-a32d-1498556ce9a3": {
+    "src/components/Navbar.tsx": "Type session parameter and import Session type"
+  },
+  "26f29467-6aab-43c6-9706-58c382b421fb": {
+    "src/app/dashboard/_components/UserMenu.tsx": "Implement basic component body to use props"
+  },
+  "93b59a71-c2ff-4012-9c01-de4877b6fc79": {
+    "src/app/dashboard/posts/%5BpostId%5D/edit/page.tsx": "Remove unused stub causing route conflict"
+  },
+  "4d4bf2fe-2e34-400c-adcd-11eaa8ae316b": {
+    "src/app/newsletters/[userId]/[postId]/[postId]/page.tsx": "Delete duplicate dynamic route to fix slug error"
+  },
+  "db0490af-80b7-4d33-bd7c-578fef242568": {
+    "src/lib/data/bookmarks.ts": "Remove unused Database import"
+  },
+  "f1ee43f4-c6ef-45c3-a93e-99f8ada87218": {
+    "src/lib/data/comments.ts": "Remove unused Database import"
+  },
+  "7e5662bc-1466-4ac2-9b1d-310a29f66ffb": {
+    "src/lib/data/posts.ts": "Remove unused Database import"
+  },
+  "7473276e-3e15-42c0-9bc2-dd9cf2cf5ca6": {
+    "src/lib/data/reactions.ts": "Remove unused Database import"
+  },
+  "f1f69e39-4748-4842-bf54-7b2e899f5293": {
+    "src/lib/data/subscriptions.ts": "Remove unused Database import"
+  },
+  "58f1d8d5-da32-4022-9a81-f789e03d86ea": {
+    "src/lib/data/views.ts": "Remove unused Database import"
+  },
+  "d8a0de83-0873-49ae-9965-f3c8ccfd24c3": {
+    "src/types/@components-ui-mode-toggle.d.ts": "Disable no-explicit-any lint rule"
+  },
+  "cd43ffe1-d338-49fa-aca2-5a72e3cd2c11": {
+    "src/types/@radix-ui__react-select.d.ts": "Disable no-explicit-any lint rule"
+  },
+  "ffa53b62-2b51-4874-a47a-a310cf3b3aa3": {
+    "src/types/@radix-ui__react-tooltip.d.ts": "Disable no-explicit-any lint rule"
+  },
+  "60a70348-e1c6-47cc-bac4-aeb04fb1dd65": {
+    "src/types/lucide-react.d.ts": "Disable no-explicit-any lint rule"
+  },
+  "10abdebc-a70a-4585-9805-f6ba6f5b631d": {
+    "src/types/next-headers.d.ts": "Disable no-explicit-any lint rule"
+  },
+  "9f6d8dcf-49fd-4253-bb49-23f4ae4865db": {
+    "src/types/next-link.d.ts": "Disable no-explicit-any lint rule"
+  },
+  "6d658dd7-efa5-47c0-b4a1-378c26051e6e": {
+    "src/types/next-metadata-interface.d.ts": "Disable no-explicit-any lint rule"
+  },
+  "723fc884-ac6f-4dec-8f54-b5cbf0265c87": {
+    "src/types/next-navigation.d.ts": "Disable no-explicit-any lint rule"
+  }
 }

--- a/src/app/dashboard/_components/UserMenu.tsx
+++ b/src/app/dashboard/_components/UserMenu.tsx
@@ -4,5 +4,10 @@ export interface UserMenuProps {
 }
 
 export function UserMenu({ user, onSignOut }: UserMenuProps) {
-  // ... existing code ...
+  if (!user) return null;
+  return (
+    <button onClick={onSignOut} className="text-sm">
+      {user.full_name || user.email || "User"}
+    </button>
+  );
 }

--- a/src/app/dashboard/collectives/_components/DashboardCollectiveCard.tsx
+++ b/src/app/dashboard/collectives/_components/DashboardCollectiveCard.tsx
@@ -11,10 +11,17 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Settings, LogOut, Users2 } from "lucide-react";
+import {
+  Settings,
+  LogOut,
+  Users2,
+  Users,
+  Eye,
+  TrendingUp,
+} from "lucide-react";
 import type { Database } from "@/lib/database.types";
 import * as React from "react";
-import useRouter from "next/navigation";
+import { useRouter } from "next/navigation";
 import { removeUserFromCollective } from "@/app/actions/collectiveActions";
 
 type Collective = Database["public"]["Tables"]["collectives"]["Row"];

--- a/src/app/dashboard/posts/%5BpostId%5D/edit/page.tsx
+++ b/src/app/dashboard/posts/%5BpostId%5D/edit/page.tsx
@@ -1,1 +1,0 @@
-import { redirect } from "next/navigation";

--- a/src/app/posts/_components/PostReactionButtons.tsx
+++ b/src/app/posts/_components/PostReactionButtons.tsx
@@ -113,4 +113,4 @@ export default function PostReactionButtons({
     </div>
   );
 }
-s;
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import supabase from "@/lib/supabase/browser";
-import type { User } from "@supabase/supabase-js";
+import type { User, Session } from "@supabase/supabase-js";
 import { Button } from "./ui/button";
 import {
   Sheet,
@@ -60,7 +60,7 @@ export default function Navbar() {
     });
     // Subscribe to auth changes on the singleton client
     const { data: authListener } = supabase.auth.onAuthStateChange(
-      (event: string, session: any) => {
+      (event: string, session: Session | null) => {
         setUser(session?.user ?? null);
         // Sync session to server cookie on sign-in/sign-out
         fetch("/api/auth/callback", {

--- a/src/lib/data/bookmarks.ts
+++ b/src/lib/data/bookmarks.ts
@@ -1,5 +1,4 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import type { Database } from "@/lib/database.types";
 
 interface ToggleBookmarkArgs {
   postId: string;

--- a/src/lib/data/comments.ts
+++ b/src/lib/data/comments.ts
@@ -1,5 +1,4 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import type { Database } from "@/lib/database.types";
 
 interface AddCommentArgs {
   postId: string;

--- a/src/lib/data/posts.ts
+++ b/src/lib/data/posts.ts
@@ -1,5 +1,4 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import type { Database } from "@/lib/database.types";
 
 export async function getPostById(postId: string) {
   const supabase = await createServerSupabaseClient();

--- a/src/lib/data/reactions.ts
+++ b/src/lib/data/reactions.ts
@@ -1,5 +1,4 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import type { Database } from "@/lib/database.types";
 
 interface TogglePostReactionArgs {
   postId: string;

--- a/src/lib/data/subscriptions.ts
+++ b/src/lib/data/subscriptions.ts
@@ -1,5 +1,4 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import type { Database } from "@/lib/database.types";
 
 export async function getUserSubscription(
   userId: string,

--- a/src/lib/data/views.ts
+++ b/src/lib/data/views.ts
@@ -1,5 +1,4 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import type { Database } from "@/lib/database.types";
 
 interface LogPostViewArgs {
   postId: string;

--- a/src/types/@components-ui-mode-toggle.d.ts
+++ b/src/types/@components-ui-mode-toggle.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
  
 declare module "@/components/ui/mode-toggle" {
   export const ModeToggle: any;

--- a/src/types/@radix-ui__react-select.d.ts
+++ b/src/types/@radix-ui__react-select.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "@radix-ui/react-select" {
   const content: any;
   export = content;

--- a/src/types/@radix-ui__react-tooltip.d.ts
+++ b/src/types/@radix-ui__react-tooltip.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
  
 declare module "@radix-ui/react-tooltip" {
   const content: any;

--- a/src/types/lucide-react.d.ts
+++ b/src/types/lucide-react.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
  
 declare module "lucide-react" {
   import * as React from "react";

--- a/src/types/next-headers.d.ts
+++ b/src/types/next-headers.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
  
 declare module "next/headers" {
   const content: any;

--- a/src/types/next-link.d.ts
+++ b/src/types/next-link.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
  
 declare module "next/link" {
   const content: any;

--- a/src/types/next-metadata-interface.d.ts
+++ b/src/types/next-metadata-interface.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "next/dist/lib/metadata/types/metadata-interface.js" {
   const value: any;
   export = value;

--- a/src/types/next-navigation.d.ts
+++ b/src/types/next-navigation.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
  
 declare module "next/navigation" {
   const content: any;

--- a/src/types/radix-ui__react-select.d.ts
+++ b/src/types/radix-ui__react-select.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "@radix-ui/react-select" {
   const content: any;
   export = content;

--- a/src/types/radix-ui__react-tooltip.d.ts
+++ b/src/types/radix-ui__react-tooltip.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "@radix-ui/react-tooltip" {
   const content: any;
   export = content;

--- a/src/types/react.d.ts
+++ b/src/types/react.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
  
 declare module "react" {
   export type ElementType = any;

--- a/src/types/supabase-js.d.ts
+++ b/src/types/supabase-js.d.ts
@@ -1,1 +1,2 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "@supabase/supabase-js";


### PR DESCRIPTION
## Summary
- remove empty duplicate `[postId]` route under newsletters
- drop encoded dashboard posts directory
- add missing icon imports and router hook fix
- clean up reaction buttons code
- type supabase session in navbar
- implement placeholder `UserMenu`
- remove unused Database imports
- silence `no-explicit-any` lint warnings for stub modules
- record changes in `change_log.json`

## Testing
- `pnpm run lint` *(fails: could not download pnpm)*