### PR TITLE
Fix navigation gaps

### DIFF
--- a/change_log.json
+++ b/change_log.json
@@ -1,0 +1,14 @@
+{
+  "3a63caae-07fd-40c6-a062-8b2ceb8bf699": {
+    "src/app/dashboard/page.tsx": "Change dashboard heading to Management Dashboard"
+  },
+  "793a8f6c-df9c-4676-81dd-ac8d188ccc7a": {
+    "src/app/dashboard/collectives/_components/DashboardCollectiveCard.tsx": "Add Add Post button for collective owners"
+  },
+  "53e2ccb5-5f1b-4734-a91c-47a33c287bed": {
+    "src/app/dashboard/collectives/[collectiveId]/page.tsx": "Redirect collective root to posts page"
+  },
+  "a1547d90-67db-4cd9-b95a-2c0235ee74a4": {
+    "src/app/dashboard/_components/SidebarNav.tsx": "Link account settings in sidebar"
+  }
+}

--- a/src/app/dashboard/_components/SidebarNav.tsx
+++ b/src/app/dashboard/_components/SidebarNav.tsx
@@ -6,6 +6,7 @@ import {
   Users2,
   UserSquare,
   Newspaper,
+  Settings as SettingsIcon,
 } from "lucide-react";
 import { SidebarLink } from "./SidebarLink";
 import type { CollectiveSummary } from "./DashboardShell";
@@ -38,6 +39,11 @@ const settingsNavItems = [
     href: "/dashboard/my-newsletter/subscribers",
     icon: Newspaper,
     label: "Newsletter",
+  },
+  {
+    href: "/settings",
+    icon: SettingsIcon,
+    label: "Account Settings",
   },
 ];
 

--- a/src/app/dashboard/collectives/[collectiveId]/page.tsx
+++ b/src/app/dashboard/collectives/[collectiveId]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function CollectiveDashboardDefault({ params }: { params: { collectiveId: string } }) {
+  redirect(`/dashboard/collectives/${params.collectiveId}/posts`);
+}

--- a/src/app/dashboard/collectives/_components/DashboardCollectiveCard.tsx
+++ b/src/app/dashboard/collectives/_components/DashboardCollectiveCard.tsx
@@ -17,6 +17,7 @@ import {
   Users2,
   Users,
   Eye,
+  Plus,
   TrendingUp,
 } from "lucide-react";
 import type { Database } from "@/lib/database.types";
@@ -137,6 +138,21 @@ export default function DashboardCollectiveCard({
             <Eye className="h-4 w-4 mr-1.5" /> View
           </Link>
         </Button>
+        {role === "Owner" && (
+          <Button
+            variant="outline"
+            size="sm"
+            asChild
+            className="flex-grow basis-1/3 sm:basis-auto"
+          >
+            <Link
+              href={`/dashboard/${collective.id}/new-post`}
+              className="flex items-center justify-center w-full"
+            >
+              <Plus className="h-4 w-4 mr-1.5" /> Add Post
+            </Link>
+          </Button>
+        )}
         {role === "Owner" ? (
           <>
             <Button

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -91,7 +91,7 @@ export default async function DashboardManagementPage() {
       <div className="sticky top-0 z-30 bg-background py-4 border-b border-border mb-6 flex flex-col md:flex-row items-center justify-between">
         <div>
           <h1 className="text-3xl md:text-4xl font-bold font-serif tracking-tight text-foreground">
-            Dashboard
+            Management Dashboard
           </h1>
         </div>
         <div className="flex items-center gap-3 mt-4 md:mt-0">


### PR DESCRIPTION
## Summary
- add Add Post action on owned collective cards
- redirect /dashboard/collectives/[id] to the posts list
- link Account Settings in sidebar nav
- rename main dashboard heading to Management Dashboard
- start change_log.json

## Testing
- `pnpm install --frozen-lockfile` *(fails: connect EHOSTUNREACH)*
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*
- `pnpm build` *(fails: connect EHOSTUNREACH)*
