### PR TITLE
Refactor editor layout and sidebar

### DIFF
--- a/src/app/posts/[postId]/edit/EditPostForm.tsx
+++ b/src/app/posts/[postId]/edit/EditPostForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useForm, SubmitHandler } from "react-hook-form";
+import { useForm, SubmitHandler, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PostFormSchema, type PostFormValues } from "@/lib/schemas/postSchemas";
 import EditorLayout from "@/components/editor/EditorLayout";
@@ -17,6 +17,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Info } from "lucide-react";
 import PostFormFields from "@/components/app/editor/form-fields/PostFormFields";
 import PostEditor from "@/components/editor/PostEditor";
+import SEOSettingsDrawer from "@/components/editor/SEOSettingsDrawer";
 
 type EditPostFormValues = PostFormValues;
 
@@ -27,7 +28,7 @@ export interface PostDataType extends Tables<"posts"> {
 interface EditPostFormProps {
   postId: string;
   initialData: PostDataType;
-  pageTitleInfo: string;
+  pageTitle: string;
 }
 
 function getInitialStatus(post: PostDataType): EditPostFormValues["status"] {
@@ -70,13 +71,14 @@ const EMPTY_LEXICAL_STATE = JSON.stringify({
 export default function EditPostForm({
   postId,
   initialData,
-  pageTitleInfo,
+  pageTitle,
 }: EditPostFormProps) {
   const router = useRouter();
   const [isProcessing, startTransition] = useTransition();
   const [serverError, setServerError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [autosaveStatus, setAutosaveStatus] = useState<string>("");
+  const [seoDrawerOpen, setSeoDrawerOpen] = useState(false);
 
   const form = useForm<EditPostFormValues>({
     resolver: zodResolver(PostFormSchema),
@@ -231,6 +233,23 @@ export default function EditPostForm({
         isSubmitting={isProcessing || isSubmitting || isDeleting}
         titlePlaceholder="Edit Post Title"
       />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setSeoDrawerOpen(true)}
+        className="w-full"
+      >
+        SEO Settings
+      </Button>
+      <Button
+        type="button"
+        onClick={handleSubmit(onSubmit)}
+        disabled={isProcessing || isSubmitting || isDeleting}
+        className="w-full"
+      >
+        {primaryButtonText}
+      </Button>
       {autosaveStatus && (
         <Alert
           variant={
@@ -273,7 +292,7 @@ export default function EditPostForm({
     </div>
   );
 
-  const mainContentNode = (
+  const canvas = (
     <PostEditor
       initialContentJSON={getValues("content")}
       placeholder="Continue writing..."
@@ -284,13 +303,11 @@ export default function EditPostForm({
   );
 
   return (
-    <EditorLayout
-      settingsSidebar={formControlsNode}
-      mainContent={mainContentNode}
-      pageTitle={pageTitleInfo}
-      onPublish={handleSubmit(onSubmit)}
-      isPublishing={isProcessing || isSubmitting}
-      publishButtonText={primaryButtonText}
-    />
+    <FormProvider {...form}>
+      <SEOSettingsDrawer open={seoDrawerOpen} onOpenChange={setSeoDrawerOpen} />
+      <EditorLayout settingsSidebar={formControlsNode} pageTitle={pageTitle}>
+        {canvas}
+      </EditorLayout>
+    </FormProvider>
   );
 }

--- a/src/app/posts/[postId]/edit/page.tsx
+++ b/src/app/posts/[postId]/edit/page.tsx
@@ -76,7 +76,7 @@ export default async function EditPostPage({
     collective_name: postData.collective?.name,
   };
 
-  const pageTitleInfo = postData.collective?.name
+  const pageTitle = postData.collective?.name
     ? `Edit Post in ${postData.collective.name}`
     : "Edit Personal Post";
 
@@ -84,7 +84,7 @@ export default async function EditPostPage({
     <EditPostForm
       postId={postId}
       initialData={initialPostData}
-      pageTitleInfo={pageTitleInfo}
+      pageTitle={pageTitle}
     />
   );
 }

--- a/src/app/posts/new/NewPostForm.tsx
+++ b/src/app/posts/new/NewPostForm.tsx
@@ -8,9 +8,9 @@ import { PostFormSchema, type PostFormValues } from '@/lib/schemas/postSchemas';
 import EditorLayout from '@/components/editor/EditorLayout';
 import PostEditor from '@/components/editor/PostEditor';
 import PostFormFields from '@/components/app/editor/form-fields/PostFormFields';
-import FileExplorer from '@/components/app/editor/sidebar/FileExplorer';
 import SEOSettingsDrawer from '@/components/editor/SEOSettingsDrawer';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import { Info } from 'lucide-react';
 import { createPost, updatePost } from '@/app/actions/postActions';
 
@@ -18,9 +18,10 @@ type NewPostFormValues = PostFormValues;
 
 interface NewPostFormProps {
   collective?: { id: string; name: string; owner_id: string } | null;
+  pageTitle: string;
 }
 
-export default function NewPostForm({ collective }: NewPostFormProps) {
+export default function NewPostForm({ collective, pageTitle }: NewPostFormProps) {
   const [isProcessing, setIsProcessing] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
   const [autosaveStatus, setAutosaveStatus] = useState<string>('');
@@ -204,17 +205,8 @@ export default function NewPostForm({ collective }: NewPostFormProps) {
             : 'Create Draft'
           : 'Publish Post';
 
-  // FileExplorer data (TODO: fetch real data)
-  const personalPosts: { id: string; title: string; status: string }[] = [];
-  const collectives: {
-    id: string;
-    name: string;
-    posts: { id: string; title: string; status: string }[];
-  }[] = [];
-
-  // Metadata bar (title, status, publish, etc.)
-  const metadataBar = (
-    <>
+  const formControlsNode = (
+    <div className="space-y-6">
       <PostFormFields
         register={register}
         errors={errors}
@@ -224,34 +216,23 @@ export default function NewPostForm({ collective }: NewPostFormProps) {
           collective ? `New post in ${collective.name}` : 'Post Title'
         }
       />
-      <button
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setSeoDrawerOpen(true)}
+        className="w-full"
+      >
+        SEO Settings
+      </Button>
+      <Button
         type="button"
         onClick={handleSubmit(onSubmit)}
         disabled={isProcessing || isSubmitting}
-        className="ml-auto btn btn-primary"
+        className="w-full"
       >
         {primaryButtonText}
-      </button>
-    </>
-  );
-
-  // Canvas (editor) - includes the real toolbar as part of PostEditor
-  const canvas = (
-    <>
-      <PostEditor
-        initialContentJSON={getValues('content')}
-        placeholder={
-          collective
-            ? `Share something with ${collective.name}...`
-            : 'Share your thoughts...'
-        }
-        onContentChange={(json) =>
-          setValue('content', json, {
-            shouldValidate: true,
-            shouldDirty: true,
-          })
-        }
-      />
+      </Button>
       {autosaveStatus && (
         <Alert
           variant={
@@ -260,7 +241,7 @@ export default function NewPostForm({ collective }: NewPostFormProps) {
               ? 'destructive'
               : 'default'
           }
-          className="mt-4 text-xs"
+          className="text-xs"
         >
           <Info className="h-4 w-4" />
           <AlertDescription>{autosaveStatus}</AlertDescription>
@@ -269,21 +250,30 @@ export default function NewPostForm({ collective }: NewPostFormProps) {
       {serverError && (
         <p className="text-sm text-destructive mt-1">{serverError}</p>
       )}
-      <SEOSettingsDrawer open={seoDrawerOpen} onOpenChange={setSeoDrawerOpen} />
-    </>
+    </div>
+  );
+
+  const canvas = (
+    <PostEditor
+      initialContentJSON={getValues('content')}
+      placeholder={
+        collective
+          ? `Share something with ${collective.name}...`
+          : 'Share your thoughts...'
+      }
+      onContentChange={(json) =>
+        setValue('content', json, {
+          shouldValidate: true,
+          shouldDirty: true,
+        })
+      }
+    />
   );
 
   return (
     <FormProvider {...form}>
-      <EditorLayout
-        fileExplorer={
-          <FileExplorer
-            personalPosts={personalPosts}
-            collectives={collectives}
-          />
-        }
-        metadataBar={metadataBar}
-      >
+      <SEOSettingsDrawer open={seoDrawerOpen} onOpenChange={setSeoDrawerOpen} />
+      <EditorLayout settingsSidebar={formControlsNode} pageTitle={pageTitle}>
         {canvas}
       </EditorLayout>
     </FormProvider>

--- a/src/app/posts/new/page.tsx
+++ b/src/app/posts/new/page.tsx
@@ -53,9 +53,6 @@ export default async function NewPostPage({
     : "Create New Post";
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-semibold">{pageTitle}</h1>
-      <NewPostForm collective={collective} />
-    </div>
+    <NewPostForm collective={collective} pageTitle={pageTitle} />
   );
 }

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -4,9 +4,9 @@ import React from "react";
 import type { ReactNode } from "react";
 
 interface EditorLayoutProps {
-  fileExplorer?: ReactNode;
-  metadataBar?: ReactNode;
   toolbar?: ReactNode;
+  settingsSidebar?: ReactNode;
+  pageTitle?: string;
   children: ReactNode; // canvas/content
 }
 
@@ -15,34 +15,32 @@ interface EditorLayoutProps {
 // |              | ├ toolbar
 // |              | └ canvas (children)
 export default function EditorLayout({
-  fileExplorer,
-  metadataBar,
   toolbar,
+  settingsSidebar,
+  pageTitle,
   children,
 }: EditorLayoutProps) {
   return (
-    <div className="flex h-screen bg-background divide-x divide-border">
-      {/* Left sidebar */}
-      {fileExplorer && (
-        <aside className="w-64 shrink-0 overflow-y-auto">{fileExplorer}</aside>
-      )}
-
-      {/* Main column */}
+    <div className="flex h-screen bg-background">
       <main className="flex-1 flex flex-col min-w-0">
-        {/* Metadata bar */}
-        {metadataBar && (
-          <div className="border-b border-border px-6 py-3 flex items-center gap-4">
-            {metadataBar}
+        {pageTitle && (
+          <div className="border-b border-border px-6 py-3">
+            <h1 className="text-xl font-semibold">{pageTitle}</h1>
           </div>
         )}
 
-        {/* Toolbar */}
         {toolbar && (
           <div className="border-b border-border px-6 py-2">{toolbar}</div>
         )}
 
-        {/* Canvas / Editor */}
-        <div className="flex-1 overflow-y-auto px-6 py-4">{children}</div>
+        <div className="flex flex-1 min-h-0">
+          <div className="flex-1 overflow-y-auto px-6 py-4">{children}</div>
+          {settingsSidebar && (
+            <aside className="w-72 shrink-0 border-l border-border px-6 py-4 overflow-y-auto">
+              {settingsSidebar}
+            </aside>
+          )}
+        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- overhaul EditorLayout to support right-hand sidebar and page header
- remove old metadata bar usage and integrate SEO drawer
- move post settings into a sidebar for new and edit forms
- adjust pages to supply page titles

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: numerous pre-existing type errors)*