### PR TITLE
Add multi-column layout nodes to editor

### DIFF
--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -312,6 +312,21 @@ function CustomInsertCommandsPlugin({
       },
       0
     );
+    // Layout container with two columns
+    const removeLayout = editor.registerCommand(
+      INSERT_LAYOUT_COMMAND,
+      () => {
+        editor.update(() => {
+          const container = new LayoutContainerNode(2);
+          container.append(new LayoutItemNode());
+          container.append(new LayoutItemNode());
+          $insertNodeToNearestRoot(container);
+        });
+        removeSlashTrigger();
+        return true;
+      },
+      0
+    );
     return () => {
       removePoll();
       removeSticky();
@@ -323,6 +338,7 @@ function CustomInsertCommandsPlugin({
       removeInlineImage();
       removeHR();
       removeCollapsible();
+      removeLayout();
     };
   }, [editor, openEmbedModal]);
   return null;
@@ -430,12 +446,10 @@ const SLASH_OPTIONS = [
   },
   {
     key: "layoutcontainer",
-    label: "Layout Container",
-    description: "Insert a layout container",
+    label: "Columns Layout",
+    description: "Insert a multi-column layout",
     action: (editor: LexicalEditor) => {
-      editor.update(() => {
-        $insertNodeToNearestRoot(new LayoutContainerNode());
-      });
+      editor.dispatchCommand(INSERT_LAYOUT_COMMAND, undefined);
     },
     setRefElement: () => {},
   },

--- a/src/components/editor/nodes/LayoutContainerNode.tsx
+++ b/src/components/editor/nodes/LayoutContainerNode.tsx
@@ -2,35 +2,69 @@
  * LayoutContainerNode for Lnked, adapted from Lexical Playground (MIT License)
  * https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/nodes/LayoutContainerNode.tsx
  */
-import { DecoratorNode, NodeKey } from "lexical";
+import {
+  ElementNode,
+  NodeKey,
+  SerializedElementNode,
+  Spread,
+} from "lexical";
 import type { JSX } from "react";
 
 // TODO: Implement LayoutContainerNode logic, import/export, and React component
-export class LayoutContainerNode extends DecoratorNode<JSX.Element> {
+export type SerializedLayoutContainerNode = Spread<
+  {
+    type: "layoutcontainer";
+    version: 1;
+    columns: number;
+  },
+  SerializedElementNode
+>;
+
+export class LayoutContainerNode extends ElementNode {
+  __columns: number;
   static getType() {
     return "layoutcontainer";
   }
   static clone(node: LayoutContainerNode) {
-    return new LayoutContainerNode(node.__key);
+    return new LayoutContainerNode(node.__columns, node.__key);
   }
-  static importJSON() {
-    return new LayoutContainerNode();
+  static importJSON(serialized: SerializedLayoutContainerNode) {
+    return new LayoutContainerNode(serialized.columns);
   }
-  exportJSON() {
-    return { ...super.exportJSON(), type: "layoutcontainer", version: 1 };
+  exportJSON(): SerializedLayoutContainerNode {
+    return {
+      ...super.exportJSON(),
+      type: "layoutcontainer",
+      version: 1,
+      columns: this.__columns,
+    };
   }
-  constructor(key?: NodeKey) {
+  constructor(columns = 2, key?: NodeKey) {
     super(key);
+    this.__columns = columns;
   }
   createDOM(): HTMLElement {
-    const el = document.createElement("div");
-    el.textContent = "[Layout Container]";
-    return el;
+    const container = document.createElement("div");
+    container.className = "grid gap-4";
+    container.style.display = "grid";
+    container.style.gridTemplateColumns = `repeat(${this.__columns}, 1fr)`;
+    return container;
   }
   updateDOM(): boolean {
     return false;
   }
-  decorate(): JSX.Element {
-    return <div>[Layout Container]</div>;
+  decorate(): JSX.Element | null {
+    return null;
   }
 }
+
+export function $createLayoutContainerNode(columns = 2): LayoutContainerNode {
+  return new LayoutContainerNode(columns);
+}
+
+export function $isLayoutContainerNode(
+  node: unknown,
+): node is LayoutContainerNode {
+  return node instanceof LayoutContainerNode;
+}
+

--- a/src/components/editor/nodes/LayoutItemNode.tsx
+++ b/src/components/editor/nodes/LayoutItemNode.tsx
@@ -2,21 +2,34 @@
  * LayoutItemNode for Lnked, adapted from Lexical Playground (MIT License)
  * https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/nodes/LayoutItemNode.tsx
  */
-import { DecoratorNode, NodeKey } from "lexical";
+import {
+  ElementNode,
+  NodeKey,
+  SerializedElementNode,
+  Spread,
+} from "lexical";
 import type { JSX } from "react";
 
 // TODO: Implement LayoutItemNode logic, import/export, and React component
-export class LayoutItemNode extends DecoratorNode<JSX.Element> {
+export type SerializedLayoutItemNode = Spread<
+  {
+    type: "layoutitem";
+    version: 1;
+  },
+  SerializedElementNode
+>;
+
+export class LayoutItemNode extends ElementNode {
   static getType() {
     return "layoutitem";
   }
   static clone(node: LayoutItemNode) {
     return new LayoutItemNode(node.__key);
   }
-  static importJSON() {
+  static importJSON(): LayoutItemNode {
     return new LayoutItemNode();
   }
-  exportJSON() {
+  exportJSON(): SerializedLayoutItemNode {
     return { ...super.exportJSON(), type: "layoutitem", version: 1 };
   }
   constructor(key?: NodeKey) {
@@ -24,13 +37,22 @@ export class LayoutItemNode extends DecoratorNode<JSX.Element> {
   }
   createDOM(): HTMLElement {
     const el = document.createElement("div");
-    el.textContent = "[Layout Item]";
+    el.className = "flex flex-col";
     return el;
   }
   updateDOM(): boolean {
     return false;
   }
-  decorate(): JSX.Element {
-    return <div>[Layout Item]</div>;
+  decorate(): JSX.Element | null {
+    return null;
   }
 }
+
+export function $createLayoutItemNode(): LayoutItemNode {
+  return new LayoutItemNode();
+}
+
+export function $isLayoutItemNode(node: unknown): node is LayoutItemNode {
+  return node instanceof LayoutItemNode;
+}
+


### PR DESCRIPTION
## Summary
- implement `LayoutContainerNode` and `LayoutItemNode`
- support inserting a two-column layout from `INSERT_LAYOUT_COMMAND`
- expose "Columns Layout" in slash menu

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: numerous existing type errors)*
- `pnpm test` *(fails: jest-environment-jsdom missing)*