### PR TITLE
Clean up debug logs and add security headers

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -43,19 +43,24 @@ export async function middleware(request: NextRequest) {
       }
     );
 
-    // Add debug logging to trace the issue
-    console.log(
-      `Middleware check path=${pathname}, wantsDashboard=${wantsDashboard}, isAuthPage=${isAuthPage}`
-    );
+    if (process.env.NODE_ENV === "development") {
+      console.log(
+        `Middleware check path=${pathname}, wantsDashboard=${wantsDashboard}, isAuthPage=${isAuthPage}`
+      );
+    }
 
     const {
       data: { session },
     } = await supabase.auth.getSession();
 
-    console.log(`Session check result: hasSession=${!!session}`);
+    if (process.env.NODE_ENV === "development") {
+      console.log(`Session check result: hasSession=${!!session}`);
+    }
 
     if (!session && wantsDashboard) {
-      console.log("No session, redirecting to sign-in");
+      if (process.env.NODE_ENV === "development") {
+        console.log("No session, redirecting to sign-in");
+      }
       const url = request.nextUrl.clone();
       url.pathname = "/sign-in";
       url.searchParams.set("redirect", pathname);
@@ -63,7 +68,9 @@ export async function middleware(request: NextRequest) {
     }
 
     if (session && isAuthPage) {
-      console.log("Has session, redirecting to dashboard");
+      if (process.env.NODE_ENV === "development") {
+        console.log("Has session, redirecting to dashboard");
+      }
       const url = request.nextUrl.clone();
       url.pathname = "/dashboard";
       return NextResponse.redirect(url);

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,24 @@ const nextConfig: NextConfig = {
     "@lexical/table",
     "@lexical/markdown",
   ],
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -15,7 +15,9 @@ export default function SignInPage() {
     setError(null);
 
     try {
-      console.log("Attempting sign in for:", formData.email);
+      if (process.env.NODE_ENV === "development") {
+        console.log("Attempting sign in for:", formData.email);
+      }
       // Create a fresh client instance for this request
       const supabase = createSupabaseBrowserClient();
 
@@ -36,11 +38,15 @@ export default function SignInPage() {
         return;
       }
 
-      console.log("Sign in successful, session established");
+      if (process.env.NODE_ENV === "development") {
+        console.log("Sign in successful, session established");
+      }
 
       // Verify the session was actually stored
       const { data: sessionCheck } = await supabase.auth.getSession();
-      console.log("Session verification after login:", !!sessionCheck.session);
+      if (process.env.NODE_ENV === "development") {
+        console.log("Session verification after login:", !!sessionCheck.session);
+      }
 
       if (!sessionCheck.session) {
         console.error("Session verification failed - not redirecting");
@@ -54,7 +60,9 @@ export default function SignInPage() {
       // Add a longer delay to ensure the session is properly registered
       // This gives cookies time to be properly set across all contexts
       setTimeout(() => {
-        console.log("Redirecting to dashboard after successful login");
+        if (process.env.NODE_ENV === "development") {
+          console.log("Redirecting to dashboard after successful login");
+        }
         router.push("/dashboard");
       }, 1000);
     } catch (err) {

--- a/src/app/actions/subscriptionActions.ts
+++ b/src/app/actions/subscriptionActions.ts
@@ -99,10 +99,12 @@ export async function unsubscribeFromEntity(
         cancel_at_period_end: true,
       }
     );
-    console.log(
-      "Stripe subscription set to cancel at period end:",
-      updatedStripeSubscription.id
-    );
+    if (process.env.NODE_ENV === "development") {
+      console.log(
+        "Stripe subscription set to cancel at period end:",
+        updatedStripeSubscription.id
+      );
+    }
 
     // Option 2: Delete immediately (more destructive)
     // await getStripe().subscriptions.del(stripeSubscriptionId);

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -6,7 +6,9 @@ import type { CookieOptions } from "@supabase/ssr";
 
 export async function POST(request: Request) {
   const { event, session } = await request.json();
-  console.log("Auth callback triggered:", event);
+  if (process.env.NODE_ENV === "development") {
+    console.log("Auth callback triggered:", event);
+  }
 
   const response = NextResponse.json({ status: "success" });
   const cookieStore = await cookies();
@@ -17,11 +19,15 @@ export async function POST(request: Request) {
       return (await cookieStore.get(name))?.value;
     },
     set(name: string, value: string, options?: CookieOptions) {
-      console.log(`Setting cookie: ${name}`);
+      if (process.env.NODE_ENV === "development") {
+        console.log(`Setting cookie: ${name}`);
+      }
       response.cookies.set(name, value, options);
     },
     remove(name: string, options?: CookieOptions) {
-      console.log(`Removing cookie: ${name}`);
+      if (process.env.NODE_ENV === "development") {
+        console.log(`Removing cookie: ${name}`);
+      }
       response.cookies.set(name, "", { ...options, maxAge: 0 });
     },
   };
@@ -40,17 +46,21 @@ export async function POST(request: Request) {
     );
 
     if (event === "SIGNED_IN" || event === "TOKEN_REFRESHED") {
-      console.log("Setting session in callback");
+      if (process.env.NODE_ENV === "development") {
+        console.log("Setting session in callback");
+      }
 
       // Explicitly log session data (without sensitive info)
-      if (session) {
-        console.log("Session received:", {
-          hasSession: !!session,
-          user_id: session.user?.id,
-          expires_at: session.expires_at,
-        });
-      } else {
-        console.log("No session data received in callback");
+      if (process.env.NODE_ENV === "development") {
+        if (session) {
+          console.log("Session received:", {
+            hasSession: !!session,
+            user_id: session.user?.id,
+            expires_at: session.expires_at,
+          });
+        } else {
+          console.log("No session data received in callback");
+        }
       }
 
       const result = await supabase.auth.setSession(session);
@@ -64,12 +74,16 @@ export async function POST(request: Request) {
 
       // Verify session was set
       const { data: sessionCheck } = await supabase.auth.getSession();
-      console.log(
-        "Session verification after setting:",
-        !!sessionCheck.session
-      );
+      if (process.env.NODE_ENV === "development") {
+        console.log(
+          "Session verification after setting:",
+          !!sessionCheck.session
+        );
+      }
     } else if (event === "SIGNED_OUT") {
-      console.log("Signing out in callback");
+      if (process.env.NODE_ENV === "development") {
+        console.log("Signing out in callback");
+      }
       await supabase.auth.signOut();
     }
 

--- a/src/app/api/stripe-webhook/route.ts
+++ b/src/app/api/stripe-webhook/route.ts
@@ -54,7 +54,9 @@ export async function POST(req: Request) {
     );
   }
 
-  console.log(`Received event in Next.js route: ${event.type}`);
+  if (process.env.NODE_ENV === "development") {
+    console.log(`Received event in Next.js route: ${event.type}`);
+  }
 
   if (relevantEvents.has(event.type)) {
     try {
@@ -85,14 +87,15 @@ export async function POST(req: Request) {
                 `Error upserting customer for user ${userId} (Next API):`,
                 customerErr.message,
               );
-            else
+            else if (process.env.NODE_ENV === "development")
               console.log(
                 `Customer mapping for user ${userId} updated (Next API).`,
               );
 
-            console.log(
-              `Checkout session completed for user ${userId}, target: ${session.metadata.targetEntityType} - ${session.metadata.targetEntityId}`,
-            );
+            if (process.env.NODE_ENV === "development")
+              console.log(
+                `Checkout session completed for user ${userId}, target: ${session.metadata.targetEntityType} - ${session.metadata.targetEntityId}`,
+              );
           } else {
             console.warn(
               'checkout.session.completed missing crucial metadata (userId, targetEntityType, targetEntityId) or not subscription (Next API):',
@@ -187,9 +190,10 @@ export async function POST(req: Request) {
               upsertErr.message,
             );
           } else {
-            console.log(
-              `Subscription ${subscriptionObject.id} upserted for user ${subscriberUserId} (Next API).`,
-            );
+            if (process.env.NODE_ENV === "development")
+              console.log(
+                `Subscription ${subscriptionObject.id} upserted for user ${subscriberUserId} (Next API).`,
+              );
           }
           break;
         }
@@ -226,9 +230,10 @@ export async function POST(req: Request) {
                 updateError.message,
               );
             } else {
-              console.log(
-                `Collective ${collective.id} Stripe status updated from webhook.`,
-              );
+              if (process.env.NODE_ENV === "development")
+                console.log(
+                  `Collective ${collective.id} Stripe status updated from webhook.`,
+                );
             }
           } else {
             console.warn(

--- a/src/app/dashboard/collectives/new/_actions.ts
+++ b/src/app/dashboard/collectives/new/_actions.ts
@@ -34,12 +34,7 @@ interface CreateCollectiveResult {
 export async function createCollective(
   inputData: unknown // Raw input from the form, to be parsed by Zod
 ): Promise<CreateCollectiveResult> {
-  // Debug: log env vars and supabase client
-  console.log("SUPABASE_URL", process.env.NEXT_PUBLIC_SUPABASE_URL);
-  console.log("SUPABASE_ANON_KEY", process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
-
   const supabase = await createServerSupabaseClient();
-  console.log("supabase.auth", supabase.auth);
 
   const {
     data: { user },
@@ -53,7 +48,7 @@ export async function createCollective(
   const validatedFields = CollectiveSchema.safeParse(inputData);
 
   if (!validatedFields.success) {
-    console.log(
+    console.error(
       "Validation errors:",
       validatedFields.error.flatten().fieldErrors
     );

--- a/src/app/dashboard/posts/page.tsx
+++ b/src/app/dashboard/posts/page.tsx
@@ -20,16 +20,7 @@ type PublishingTargetCollective = Pick<
 >;
 
 export default async function MyPostsPage() {
-  // TEMP DEBUG: Log env vars and test a simple query
-  console.log("SUPABASE_URL", process.env.NEXT_PUBLIC_SUPABASE_URL);
-  console.log("SUPABASE_ANON_KEY", process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
-
   const supabase = await createServerSupabaseClient();
-  const { data: testPosts, error: testPostsError } = await supabase
-    .from("posts")
-    .select("*")
-    .limit(1);
-  console.log("Test posts query:", { testPosts, testPostsError });
 
   const {
     data: { session },

--- a/src/components/editor/plugins/SlashMenuPlugin.tsx
+++ b/src/components/editor/plugins/SlashMenuPlugin.tsx
@@ -180,19 +180,6 @@ const SlashMenuPlugin = () => {
     return editor.registerCommand(
       KEY_DOWN_COMMAND,
       (event) => {
-        console.log("[SlashMenuPlugin] KEY_DOWN_COMMAND:", event.key);
-        const selection = $getSelection();
-        if (selection) {
-          // Log selection details
-          // @ts-expect-error selection may not have constructor
-          console.log(
-            "[SlashMenuPlugin] selection:",
-            selection.constructor.name,
-            selection
-          );
-        } else {
-          console.log("[SlashMenuPlugin] No selection");
-        }
         if (
           event.key === "/" &&
           $isRangeSelection($getSelection()) &&
@@ -218,12 +205,6 @@ const SlashMenuPlugin = () => {
             if (domElem) {
               const rect = domElem.getBoundingClientRect();
               setMenuPosition({ x: rect.left, y: rect.bottom });
-              console.log(
-                "[SlashMenuPlugin] menuPosition:",
-                rect.left,
-                rect.bottom,
-                rect
-              );
             } else {
               setMenuPosition(null);
             }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -3,9 +3,6 @@ import { createServerClient } from "@supabase/ssr";
 import type { Database } from "../database.types";
 
 export async function createServerSupabaseClient() {
-  // Debug: log env vars and Supabase client creation
-  console.log("SUPABASE_URL", process.env.NEXT_PUBLIC_SUPABASE_URL);
-  console.log("SUPABASE_ANON_KEY", process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
 
   const cookieStore = await cookies();
 
@@ -21,6 +18,5 @@ export async function createServerSupabaseClient() {
     }
   );
 
-  console.log("supabase.auth", supabase.auth);
   return supabase;
 }


### PR DESCRIPTION
## Summary
- guard middleware logging behind dev mode
- remove debugging from Supabase server client
- remove env key logs in collective creation and posts page
- guard auth callback and stripe webhook logs
- guard client logs on sign in
- guard subscription action info
- drop editor plugin logs
- add basic security headers via Next.js config

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Module '"next/navigation"' has no exported member ...)*
- `pnpm test`