### PR TITLE
Remove outdated metadata interface types

### DIFF
--- a/src/types/next-metadata-fix.d.ts
+++ b/src/types/next-metadata-fix.d.ts
@@ -1,6 +1,0 @@
-declare module "next/dist/lib/metadata/types/metadata-interface.js" {
-  export type ResolvingMetadata =
-    import("next/dist/lib/metadata/types/metadata-interface").ResolvingMetadata;
-  export type ResolvingViewport =
-    import("next/dist/lib/metadata/types/metadata-interface").ResolvingViewport;
-}

--- a/src/types/next-metadata-interface.d.ts
+++ b/src/types/next-metadata-interface.d.ts
@@ -1,5 +1,0 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-declare module "next/dist/lib/metadata/types/metadata-interface.js" {
-  const value: any;
-  export = value;
-}


### PR DESCRIPTION
## Summary
- delete the old metadata type workarounds

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Module '"next/navigation"' has no exported member 'useRouter', etc.)*