### PR TITLE
Fix Next.js dynamic route param types

### DIFF
--- a/src/app/(editor)/posts/[postId]/edit/page.tsx
+++ b/src/app/(editor)/posts/[postId]/edit/page.tsx
@@ -5,9 +5,9 @@ import EditPostForm, { type PostDataType } from "./EditPostForm"; // Import the 
 export default async function EditPostPage({
   params,
 }: {
-  params: Promise<{ postId: string }>;
+  params: { postId: string };
 }) {
-  const { postId } = await params;
+  const { postId } = params;
   const supabase = await createServerSupabaseClient();
 
   const {

--- a/src/app/[collectiveSlug]/[postId]/page.tsx
+++ b/src/app/[collectiveSlug]/[postId]/page.tsx
@@ -42,9 +42,9 @@ export type CollectivePostViewData =
 export default async function PostPage({
   params,
 }: {
-  params: Promise<{ collectiveSlug: string; postId: string }>;
+  params: { collectiveSlug: string; postId: string };
 }) {
-  const { collectiveSlug, postId } = await params;
+  const { collectiveSlug, postId } = params;
   const supabase = await createServerSupabaseClient();
 
   const {

--- a/src/app/[collectiveSlug]/layout.tsx
+++ b/src/app/[collectiveSlug]/layout.tsx
@@ -9,9 +9,9 @@ export default async function CollectiveLayout({
   params,
 }: {
   children: React.ReactNode;
-  params: Promise<{ collectiveSlug: string }>;
+  params: { collectiveSlug: string };
 }) {
-  const { collectiveSlug } = await params;
+  const { collectiveSlug } = params;
   if (process.env.NODE_ENV === "development") {
     console.log("Rendering layout for collective slug:", collectiveSlug);
   }

--- a/src/app/[collectiveSlug]/page.tsx
+++ b/src/app/[collectiveSlug]/page.tsx
@@ -9,9 +9,9 @@ import SubscribeButton from "@/components/app/newsletters/molecules/SubscribeBut
 export default async function Page({
   params,
 }: {
-  params: Promise<{ collectiveSlug: string }>;
+  params: { collectiveSlug: string };
 }) {
-  const { collectiveSlug } = await params;
+  const { collectiveSlug } = params;
   const supabase = await createServerSupabaseClient();
 
   const {

--- a/src/app/newsletters/[userId]/page.tsx
+++ b/src/app/newsletters/[userId]/page.tsx
@@ -16,9 +16,9 @@ export type PostWithLikesData = Database["public"]["Tables"]["posts"]["Row"] & {
 export default async function IndividualNewsletterPage({
   params,
 }: {
-  params: Promise<{ userId: string }>;
+  params: { userId: string };
 }) {
-  const { userId } = await params;
+  const { userId } = params;
   const supabase = await createServerSupabaseClient();
 
   const {

--- a/src/app/posts/[postId]/page.tsx
+++ b/src/app/posts/[postId]/page.tsx
@@ -11,9 +11,9 @@ import { LexicalRenderer } from '@/components/ui/LexicalRenderer';
 export default async function IndividualPostViewPage({
   params,
 }: {
-  params: Promise<{ postId: string }>;
+  params: { postId: string };
 }) {
-  const { postId } = await params;
+  const { postId } = params;
   const supabase = await createServerSupabaseClient();
 
   const {


### PR DESCRIPTION
## Notes
- Updated all dynamic route files to accept synchronous `params` objects instead of `Promise`.

## Summary
- corrected `params` typing in `/posts/[postId]` page
- corrected `params` typing in `[collectiveSlug]/[postId]` page
- corrected `params` typing in editor post edit page
- corrected `params` typing in newsletter and collective pages and layout

## Testing
- `pnpm test`