### PR TITLE
Update navigation APIs for Next 15

### DIFF
--- a/src/app/[collectiveSlug]/page.tsx
+++ b/src/app/[collectiveSlug]/page.tsx
@@ -1,5 +1,5 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import ProfileFeed from "@/components/app/profile/ProfileFeed";
 import type { MicroPost } from "@/components/app/profile/MicrothreadPanel";
 import { Button } from "@/components/ui/button";
@@ -30,7 +30,7 @@ export default async function Page({
       `Error fetching collective ${collectiveSlug}:`,
       collectiveError
     );
-    redirect("/not-found");
+    notFound();
   }
 
   // Fetch posts for this collective using denormalized like/dislike counts

--- a/src/app/api/stripe-webhook/route.ts
+++ b/src/app/api/stripe-webhook/route.ts
@@ -3,7 +3,6 @@ import { getStripe } from '@/lib/stripe';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import type Stripe from 'stripe';
 import type { Database } from '@/lib/database.types';
-import { headers } from 'next/headers';
 
 const relevantEvents = new Set([
   'checkout.session.completed',
@@ -26,7 +25,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const sig = (headers() as unknown as Headers).get('stripe-signature');
+  const sig = req.headers.get('stripe-signature');
   const rawBody = await req.text();
 
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;

--- a/src/app/dashboard/collectives/[collectiveId]/manage/members/page.tsx
+++ b/src/app/dashboard/collectives/[collectiveId]/manage/members/page.tsx
@@ -1,6 +1,6 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import type { Tables } from "@/lib/database.types";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
 import ManageMembersClientUI from "./ManageMembersClientUI"; // New client component
 
@@ -45,7 +45,7 @@ export default async function ManageCollectiveMembersPage({
       `Error fetching collective ${collectiveId} for member management:`,
       collectiveError?.message
     );
-    redirect("/not-found");
+    notFound();
   }
 
   // Permission check: Only owner can manage members (for now, can be expanded to admin role members)
@@ -54,7 +54,7 @@ export default async function ManageCollectiveMembersPage({
       `User ${currentUser.id} attempted to manage members for collective ${collectiveId} without ownership.`
     );
     // redirect('/dashboard'); // Or a more specific unauthorized page
-    redirect("/not-found");
+    notFound();
   }
 
   const { data: members, error: membersError } = await supabase

--- a/src/app/dashboard/collectives/[collectiveId]/subscribers/page.tsx
+++ b/src/app/dashboard/collectives/[collectiveId]/subscribers/page.tsx
@@ -1,6 +1,6 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { Enums } from "@/lib/database.types";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
 import {
   Table,
@@ -73,7 +73,7 @@ export default async function SubscribersPage({
       `Error fetching collective ${collectiveId}:`,
       collectiveError?.message
     );
-    redirect("/not-found");
+    notFound();
   }
 
   if (collective.owner_id !== currentUser.id) {
@@ -81,7 +81,7 @@ export default async function SubscribersPage({
     console.warn(
       `User ${currentUser.id} tried to access subscribers for collective ${collectiveId} they do not own.`
     );
-    redirect("/not-found");
+    notFound();
   }
 
   // 2. Fetch subscribers to this collective

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div className="container mx-auto p-8 text-center">
+      <h1 className="text-4xl font-bold mb-4">404 - Page Not Found</h1>
+      <p className="text-muted-foreground">The page you are looking for does not exist.</p>
+    </div>
+  );
+}

--- a/src/app/users/[userId]/page.tsx
+++ b/src/app/users/[userId]/page.tsx
@@ -1,5 +1,5 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import ProfileFeed from "@/components/app/profile/ProfileFeed";
 import type { MicroPost } from "@/components/app/profile/MicrothreadPanel";
 import { Button } from "@/components/ui/button";
@@ -22,7 +22,7 @@ export default async function Page({ params }: { params: { userId: string } }) {
 
   if (profileError || !profile) {
     console.error("Error fetching user", userId, profileError);
-    redirect("/not-found");
+    notFound();
   }
 
   const { data: postsData, error: postsError } = await supabase.rpc(

--- a/src/components/app/editor/sidebar/FileExplorer.tsx
+++ b/src/components/app/editor/sidebar/FileExplorer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";


### PR DESCRIPTION
## Summary
- mark FileExplorer as a client component
- use request headers for Stripe webhook
- handle 404s with notFound instead of redirect
- add global `not-found.tsx` page

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Module '"next/navigation"' has no exported member and other TS errors)*
- `pnpm test`