### PR TITLE
Fix node casting in Lexical components

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/editor/nodes/InlineImageNode.tsx
+++ b/src/components/editor/nodes/InlineImageNode.tsx
@@ -2,9 +2,19 @@
  * InlineImageNode for Lnked, adapted from Lexical Playground (MIT License)
  * https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/nodes/InlineImageNode.tsx
  */
-import { DecoratorNode, NodeKey } from "lexical";
+import { DecoratorNode, NodeKey, SerializedLexicalNode, Spread } from "lexical";
 import type { JSX } from "react";
 import Image from "next/image";
+
+export type SerializedInlineImageNode = Spread<
+  {
+    type: "inlineimage";
+    version: 1;
+    src?: string;
+    alt?: string;
+  },
+  SerializedLexicalNode
+>;
 
 export class InlineImageNode extends DecoratorNode<JSX.Element> {
   __src: string;
@@ -16,9 +26,11 @@ export class InlineImageNode extends DecoratorNode<JSX.Element> {
   static clone(node: InlineImageNode) {
     return new InlineImageNode(node.__src, node.__alt, node.__key);
   }
-  static importJSON(serialized: import("lexical").SerializedLexicalNode) {
-    const data = serialized as unknown as { src?: string; alt?: string };
-    return new InlineImageNode(data.src ?? "", data.alt ?? "Inline Image");
+  static importJSON(serialized: SerializedInlineImageNode) {
+    return new InlineImageNode(
+      serialized.src ?? "",
+      serialized.alt ?? "Inline Image",
+    );
   }
   exportJSON() {
     return {

--- a/src/components/editor/nodes/PollNode.tsx
+++ b/src/components/editor/nodes/PollNode.tsx
@@ -2,7 +2,13 @@
  * PollNode for Lnked, adapted from Lexical Playground (MIT License)
  * https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/nodes/PollNode.tsx
  */
-import { DecoratorNode, NodeKey, SerializedLexicalNode, Spread } from 'lexical';
+import {
+  DecoratorNode,
+  NodeKey,
+  SerializedLexicalNode,
+  Spread,
+  $getNodeByKey,
+} from 'lexical';
 import React, { useState } from 'react';
 import type { JSX } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
@@ -99,11 +105,9 @@ function PollComponent({
   // Update node in editor
   const updateNode = (newQuestion: string, newOptions: PollOption[]) => {
     editor.update(() => {
-      const pollNode = editor._editorState._nodeMap.get(nodeKey) as
-        | PollNode
-        | undefined;
-      if (pollNode) {
-        const writable = pollNode.getWritable();
+      const node = $getNodeByKey(nodeKey);
+      if (node instanceof PollNode) {
+        const writable = node.getWritable();
         writable.__question = newQuestion;
         writable.__options = newOptions;
       }

--- a/src/components/editor/nodes/StickyNode.tsx
+++ b/src/components/editor/nodes/StickyNode.tsx
@@ -2,7 +2,7 @@
  * StickyNode for Lnked, adapted from Lexical Playground (MIT License)
  * https://github.com/facebook/lexical/blob/main/packages/lexical-playground/src/nodes/StickyNode.tsx
  */
-import { DecoratorNode, NodeKey } from 'lexical';
+import { DecoratorNode, NodeKey, $getNodeByKey } from 'lexical';
 import type { JSX } from 'react';
 import React, { useState } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
@@ -98,11 +98,9 @@ function StickyComponent({
 
   const updateNode = (newText: string, newColor: string) => {
     editor.update(() => {
-      const stickyNode = editor._editorState._nodeMap.get(nodeKey) as
-        | StickyNode
-        | undefined;
-      if (stickyNode) {
-        const writable = stickyNode.getWritable();
+      const node = $getNodeByKey(nodeKey);
+      if (node instanceof StickyNode) {
+        const writable = node.getWritable();
         writable.__text = newText;
         writable.__color = newColor;
       }


### PR DESCRIPTION
## Summary
- refactor PollNode and StickyNode updates to use `$getNodeByKey`
- type the InlineImageNode JSON import to avoid `unknown` cast
- update generated next-env types

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Conversion of type 'LexicalNode' to type ...)*
- `pnpm test`
