### PR TITLE
Add follower counts and lists

### DIFF
--- a/src/app/[collectiveSlug]/followers/page.tsx
+++ b/src/app/[collectiveSlug]/followers/page.tsx
@@ -1,0 +1,71 @@
+import { createServerSupabaseClient } from '@/lib/supabase/server';
+import { notFound } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default async function Page({
+  params,
+}: {
+  params: { collectiveSlug: string };
+}) {
+  const { collectiveSlug } = params;
+  const supabase = await createServerSupabaseClient();
+
+  const { data: collectiveData, error: collectiveError } = await supabase
+    .from('collectives')
+    .select('id, name')
+    .eq('slug', collectiveSlug)
+    .single();
+
+  if (collectiveError || !collectiveData) {
+    notFound();
+  }
+
+  const { data: followersData, error: followersError } = await supabase
+    .from('follows')
+    .select(
+      'follower_id, follower:users!follower_id(id, full_name, avatar_url)',
+    )
+    .eq('following_id', collectiveData.id);
+
+  if (followersError) {
+    console.error('Error fetching followers:', followersError);
+  }
+
+  const followers = followersData ?? [];
+
+  return (
+    <div className="container mx-auto p-4 md:p-6">
+      <h1 className="text-3xl font-bold mb-4">
+        Followers of {collectiveData.name}
+      </h1>
+      {followers.length === 0 ? (
+        <p className="text-muted-foreground">No followers yet.</p>
+      ) : (
+        <ul className="space-y-4">
+          {followers.map((f) =>
+            f.follower ? (
+              <li key={f.follower.id} className="flex items-center gap-3">
+                {f.follower.avatar_url && (
+                  <Image
+                    src={f.follower.avatar_url}
+                    alt={`${f.follower.full_name ?? 'Follower'} avatar`}
+                    width={40}
+                    height={40}
+                    className="rounded-full object-cover"
+                  />
+                )}
+                <Link
+                  href={`/users/${f.follower.id}`}
+                  className="hover:underline font-medium"
+                >
+                  {f.follower.full_name ?? 'User'}
+                </Link>
+              </li>
+            ) : null,
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/[collectiveSlug]/page.tsx
+++ b/src/app/[collectiveSlug]/page.tsx
@@ -31,7 +31,7 @@ export default async function Page({
     .single();
 
   const collective = collectiveData as
-    | (Database["public"]["Tables"]["collectives"]["Row"] & {
+    | (Database['public']['Tables']['collectives']['Row'] & {
         owner: { full_name: string | null } | null;
       })
     | null;
@@ -49,6 +49,11 @@ export default async function Page({
     .from('collective_members')
     .select('*', { count: 'exact', head: true })
     .eq('collective_id', collective.id);
+
+  const { count: followerCount } = await supabase
+    .from('follows')
+    .select('*', { count: 'exact', head: true })
+    .eq('following_id', collective.id);
 
   // Fetch posts for this collective using denormalized like/dislike counts
   const { data: postsData, error: postsError } = await supabase
@@ -115,7 +120,14 @@ export default async function Page({
             {collective.owner?.full_name
               ? `Owned by ${collective.owner.full_name} – `
               : ''}
-            {memberCount ?? 0} member{(memberCount ?? 0) === 1 ? '' : 's'}
+            <Link
+              href={`/${collectiveSlug}/followers`}
+              className="hover:underline"
+            >
+              {followerCount ?? 0} follower
+              {(followerCount ?? 0) === 1 ? '' : 's'}
+            </Link>{' '}
+            – {memberCount ?? 0} member{(memberCount ?? 0) === 1 ? '' : 's'}
           </p>
           {collective.tags && collective.tags.length > 0 && (
             <div className="flex flex-wrap justify-center gap-1 mt-1">

--- a/src/app/users/[userId]/followers/page.tsx
+++ b/src/app/users/[userId]/followers/page.tsx
@@ -1,0 +1,67 @@
+import { createServerSupabaseClient } from '@/lib/supabase/server';
+import { notFound } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default async function Page({ params }: { params: { userId: string } }) {
+  const { userId } = params;
+  const supabase = await createServerSupabaseClient();
+
+  const { data: profile, error: profileError } = await supabase
+    .from('users')
+    .select('id, full_name')
+    .eq('id', userId)
+    .single();
+
+  if (profileError || !profile) {
+    notFound();
+  }
+
+  const { data: followersData, error: followersError } = await supabase
+    .from('follows')
+    .select(
+      'follower_id, follower:users!follower_id(id, full_name, avatar_url)',
+    )
+    .eq('following_id', userId);
+
+  if (followersError) {
+    console.error('Error fetching followers:', followersError);
+  }
+
+  const followers = followersData ?? [];
+
+  return (
+    <div className="container mx-auto p-4 md:p-6">
+      <h1 className="text-3xl font-bold mb-4">
+        Followers of {profile.full_name ?? 'User'}
+      </h1>
+      {followers.length === 0 ? (
+        <p className="text-muted-foreground">No followers yet.</p>
+      ) : (
+        <ul className="space-y-4">
+          {followers.map((f) =>
+            f.follower ? (
+              <li key={f.follower.id} className="flex items-center gap-3">
+                {f.follower.avatar_url && (
+                  <Image
+                    src={f.follower.avatar_url}
+                    alt={`${f.follower.full_name ?? 'Follower'} avatar`}
+                    width={40}
+                    height={40}
+                    className="rounded-full object-cover"
+                  />
+                )}
+                <Link
+                  href={`/users/${f.follower.id}`}
+                  className="hover:underline font-medium"
+                >
+                  {f.follower.full_name ?? 'User'}
+                </Link>
+              </li>
+            ) : null,
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/users/[userId]/page.tsx
+++ b/src/app/users/[userId]/page.tsx
@@ -96,7 +96,13 @@ export default async function Page({
             {profile.full_name ?? 'User'}
           </h1>
           <p className="text-sm text-muted-foreground">
-            {followerCount ?? 0} follower{(followerCount ?? 0) === 1 ? '' : 's'}{' '}
+            <Link
+              href={`/users/${profile.id}/followers`}
+              className="hover:underline"
+            >
+              {followerCount ?? 0} follower
+              {(followerCount ?? 0) === 1 ? '' : 's'}
+            </Link>{' '}
             – {subscriberCount ?? 0} subscriber
             {(subscriberCount ?? 0) === 1 ? '' : 's'}
           </p>


### PR DESCRIPTION
## Summary
- link follower counts on user profiles
- display follower counts on collective pages
- show list of user followers
- show list of collective followers

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
