### PR TITLE
Extend follows to collectives

### DIFF
--- a/src/app/[collectiveSlug]/followers/page.tsx
+++ b/src/app/[collectiveSlug]/followers/page.tsx
@@ -26,7 +26,8 @@ export default async function Page({
     .select(
       'follower_id, follower:users!follower_id(id, full_name, avatar_url)',
     )
-    .eq('following_id', collectiveData.id);
+    .eq('following_id', collectiveData.id)
+    .eq('following_type', 'collective');
 
   if (followersError) {
     console.error('Error fetching followers:', followersError);

--- a/src/app/[collectiveSlug]/page.tsx
+++ b/src/app/[collectiveSlug]/page.tsx
@@ -53,7 +53,8 @@ export default async function Page({
   const { count: followerCount } = await supabase
     .from('follows')
     .select('*', { count: 'exact', head: true })
-    .eq('following_id', collective.id);
+    .eq('following_id', collective.id)
+    .eq('following_type', 'collective');
 
   // Fetch posts for this collective using denormalized like/dislike counts
   const { data: postsData, error: postsError } = await supabase

--- a/src/app/actions/followActions.ts
+++ b/src/app/actions/followActions.ts
@@ -28,7 +28,11 @@ export async function followUser(
 
   const { error: insertError } = await supabase
     .from("follows")
-    .insert({ follower_id: user.id, following_id: userIdToFollow });
+    .insert({
+      follower_id: user.id,
+      following_id: userIdToFollow,
+      following_type: "user",
+    });
 
   if (insertError) {
     console.error("Error following user:", insertError.message);
@@ -66,7 +70,11 @@ export async function unfollowUser(
   const { error: deleteError } = await supabase
     .from("follows")
     .delete()
-    .match({ follower_id: user.id, following_id: userIdToUnfollow });
+    .match({
+      follower_id: user.id,
+      following_id: userIdToUnfollow,
+      following_type: "user",
+    });
 
   if (deleteError) {
     console.error("Error unfollowing user:", deleteError.message);
@@ -78,6 +86,99 @@ export async function unfollowUser(
 
   revalidatePath(`/newsletters/${userIdToUnfollow}`);
   revalidatePath(`/newsletters/${user.id}`);
+  revalidatePath("/");
+
+  return { success: true };
+}
+
+export async function followCollective(
+  collectiveId: string,
+): Promise<FollowActionResult> {
+  const supabase = await createServerSupabaseClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { success: false, error: "User not authenticated." };
+  }
+
+  const { data: collective, error: collectiveError } = await supabase
+    .from("collectives")
+    .select("owner_id, slug")
+    .eq("id", collectiveId)
+    .single();
+
+  if (collectiveError || !collective) {
+    return { success: false, error: "Collective not found." };
+  }
+
+  if (collective.owner_id === user.id) {
+    return { success: false, error: "You cannot follow your own collective." };
+  }
+
+  const { error: insertError } = await supabase.from("follows").insert({
+    follower_id: user.id,
+    following_id: collectiveId,
+    following_type: "collective",
+  });
+
+  if (insertError) {
+    console.error("Error following collective:", insertError.message);
+    if (insertError.code === "23505") {
+      return { success: false, error: "You are already following this collective." };
+    }
+    return { success: false, error: `Failed to follow collective: ${insertError.message}` };
+  }
+
+  revalidatePath(`/${collective.slug}`);
+  revalidatePath("/");
+
+  return { success: true };
+}
+
+export async function unfollowCollective(
+  collectiveId: string,
+): Promise<FollowActionResult> {
+  const supabase = await createServerSupabaseClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { success: false, error: "User not authenticated." };
+  }
+
+  const { data: collective } = await supabase
+    .from("collectives")
+    .select("slug")
+    .eq("id", collectiveId)
+    .single();
+
+  const { error: deleteError } = await supabase
+    .from("follows")
+    .delete()
+    .match({
+      follower_id: user.id,
+      following_id: collectiveId,
+      following_type: "collective",
+    });
+
+  if (deleteError) {
+    console.error("Error unfollowing collective:", deleteError.message);
+    return {
+      success: false,
+      error: `Failed to unfollow collective: ${deleteError.message}`,
+    };
+  }
+
+  if (collective) {
+    revalidatePath(`/${collective.slug}`);
+  }
   revalidatePath("/");
 
   return { success: true };

--- a/src/app/newsletters/[userId]/page.tsx
+++ b/src/app/newsletters/[userId]/page.tsx
@@ -80,7 +80,8 @@ export default async function IndividualNewsletterPage({
       .from("follows")
       .select("*", { count: "exact", head: true })
       .eq("follower_id", currentUser.id)
-      .eq("following_id", author.id);
+      .eq("following_id", author.id)
+      .eq("following_type", "user");
 
     if (followError) {
       console.error("Error checking follow status:", followError.message);

--- a/src/app/users/[userId]/followers/page.tsx
+++ b/src/app/users/[userId]/followers/page.tsx
@@ -22,7 +22,8 @@ export default async function Page({ params }: { params: { userId: string } }) {
     .select(
       'follower_id, follower:users!follower_id(id, full_name, avatar_url)',
     )
-    .eq('following_id', userId);
+    .eq('following_id', userId)
+    .eq('following_type', 'user');
 
   if (followersError) {
     console.error('Error fetching followers:', followersError);

--- a/src/app/users/[userId]/page.tsx
+++ b/src/app/users/[userId]/page.tsx
@@ -37,7 +37,8 @@ export default async function Page({
   const { count: followerCount } = await supabase
     .from('follows')
     .select('*', { count: 'exact', head: true })
-    .eq('following_id', userId);
+    .eq('following_id', userId)
+    .eq('following_type', 'user');
 
   const { count: subscriberCount } = await supabase
     .from('subscriptions')

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -411,16 +411,19 @@ export type Database = {
           created_at: string
           follower_id: string
           following_id: string
+          following_type: Database["public"]["Enums"]["member_entity_type"]
         }
         Insert: {
           created_at?: string
           follower_id: string
           following_id: string
+          following_type: Database["public"]["Enums"]["member_entity_type"]
         }
         Update: {
           created_at?: string
           follower_id?: string
           following_id?: string
+          following_type?: Database["public"]["Enums"]["member_entity_type"]
         }
         Relationships: [
           {


### PR DESCRIPTION
## Summary
- add `following_type` column to generated types
- filter follow queries by following type
- update follow user logic to write `following_type: 'user'`
- implement followCollective/unfollowCollective actions

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
