### PR TITLE
Add follow button for collectives

### DIFF
--- a/src/components/FollowCollectiveButton.tsx
+++ b/src/components/FollowCollectiveButton.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState, useTransition, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { UserPlus, UserMinus, Loader2 } from 'lucide-react';
+import {
+  followCollective,
+  unfollowCollective,
+} from '@/app/actions/followActions';
+import { createSupabaseBrowserClient } from '@/lib/supabase/browser';
+import { useRouter, usePathname } from 'next/navigation';
+
+interface FollowCollectiveButtonProps {
+  targetCollectiveId: string;
+  targetCollectiveName: string;
+  initialIsFollowing: boolean;
+  currentUserId?: string | null;
+}
+
+export default function FollowCollectiveButton({
+  targetCollectiveId,
+  targetCollectiveName,
+  initialIsFollowing,
+  currentUserId: initialCurrentUserId,
+}: FollowCollectiveButtonProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+  const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
+  const [isLoadingCurrentUser, setIsLoadingCurrentUser] =
+    useState(!initialCurrentUserId);
+  const [actualCurrentUserId, setActualCurrentUserId] = useState<string | null>(
+    initialCurrentUserId || null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const supabase = createSupabaseBrowserClient();
+
+  useEffect(() => {
+    setIsFollowing(initialIsFollowing);
+  }, [initialIsFollowing]);
+
+  useEffect(() => {
+    if (!initialCurrentUserId) {
+      const fetchUser = async () => {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        setActualCurrentUserId(user?.id || null);
+        setIsLoadingCurrentUser(false);
+      };
+      fetchUser();
+    } else {
+      setIsLoadingCurrentUser(false);
+    }
+  }, [initialCurrentUserId, supabase]);
+
+  const handleFollowToggle = async () => {
+    if (!actualCurrentUserId) {
+      router.push(`/sign-in?redirect=${pathname}`);
+      return;
+    }
+
+    const previousIsFollowing = isFollowing;
+    setIsFollowing(!isFollowing);
+
+    startTransition(async () => {
+      const action = previousIsFollowing
+        ? unfollowCollective
+        : followCollective;
+      const result = await action(targetCollectiveId);
+      if (!result.success) {
+        setIsFollowing(previousIsFollowing);
+        setError(result.error || 'Action failed. Please try again.');
+      } else {
+        setError(null);
+      }
+    });
+  };
+
+  if (isLoadingCurrentUser) {
+    return (
+      <Button disabled className="animate-pulse w-[120px]">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Loading
+      </Button>
+    );
+  }
+
+  if (!actualCurrentUserId) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      {error && (
+        <Alert variant="destructive">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <Button
+        onClick={handleFollowToggle}
+        disabled={isPending || isLoadingCurrentUser}
+        variant={isFollowing ? 'outline' : 'default'}
+        size="sm"
+        aria-label={
+          isFollowing
+            ? `Unfollow ${targetCollectiveName}`
+            : `Follow ${targetCollectiveName}`
+        }
+      >
+        {isPending ? (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        ) : isFollowing ? (
+          <UserMinus className="mr-2 h-4 w-4" />
+        ) : (
+          <UserPlus className="mr-2 h-4 w-4" />
+        )}
+        {isPending
+          ? 'Processing...'
+          : isFollowing
+            ? `Unfollow ${targetCollectiveName}`
+            : `Follow ${targetCollectiveName}`}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/__tests__/FollowCollectiveButton.test.tsx
+++ b/src/components/__tests__/FollowCollectiveButton.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import FollowCollectiveButton from '../FollowCollectiveButton';
+
+jest.mock('../../app/actions/followActions', () => ({
+  followCollective: jest.fn(async () => ({ success: true })),
+  unfollowCollective: jest.fn(async () => ({ success: true })),
+}));
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/foo',
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock('../../lib/supabase/browser', () => ({
+  createSupabaseBrowserClient: () => ({
+    auth: { getUser: () => Promise.resolve({ data: { user: null } }) },
+  }),
+}));
+
+describe('FollowCollectiveButton', () => {
+  it('renders nothing when user is not logged in', async () => {
+    render(
+      <FollowCollectiveButton
+        targetCollectiveId="1"
+        targetCollectiveName="foo"
+        initialIsFollowing={false}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow logged in users to follow collectives
- create `FollowCollectiveButton` for following/unfollowing
- render the follow button on collective profiles
- test follow button logic for collectives

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
