### PR TITLE
feat: unify route authentication gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Copy `.env.example` to `.env.local` and provide your own values. This file lists
 all keys required for Supabase, Stripe, Resend and other services used by the
 app.
 
+### Routing Updates
+
+Collective pages now live under `/collectives/[slug]` instead of directly at the
+root. Account settings have moved to `/dashboard/settings`. Old URLs under the
+previous structure redirect automatically.
+
 ## 📚 Documentation & Resources
 
 - [Lexical Docs](https://lexical.dev/docs)

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,10 +4,13 @@ import type { CookieOptions } from "@supabase/ssr";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const wantsDashboard = pathname.startsWith("/dashboard");
+  const requiresAuth =
+    pathname.startsWith("/dashboard") ||
+    pathname === "/posts/new" ||
+    (pathname.startsWith("/posts/") && pathname.endsWith("/edit"));
   const isAuthPage = pathname === "/sign-in" || pathname === "/sign-up";
 
-  if (!wantsDashboard && !isAuthPage) return NextResponse.next();
+  if (!requiresAuth && !isAuthPage) return NextResponse.next();
 
   let response = NextResponse.next({ request });
 
@@ -45,7 +48,7 @@ export async function middleware(request: NextRequest) {
 
     if (process.env.NODE_ENV === "development") {
       console.log(
-        `Middleware check path=${pathname}, wantsDashboard=${wantsDashboard}, isAuthPage=${isAuthPage}`
+        `Middleware check path=${pathname}, requiresAuth=${requiresAuth}, isAuthPage=${isAuthPage}`
       );
     }
 
@@ -57,7 +60,7 @@ export async function middleware(request: NextRequest) {
       console.log(`Session check result: hasSession=${!!session}`);
     }
 
-    if (!session && wantsDashboard) {
+    if (!session && requiresAuth) {
       if (process.env.NODE_ENV === "development") {
         console.log("No session, redirecting to sign-in");
       }
@@ -85,5 +88,11 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/sign-in", "/sign-up"],
+  matcher: [
+    "/dashboard/:path*",
+    "/posts/:path*/edit",
+    "/posts/new",
+    "/sign-in",
+    "/sign-up",
+  ],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,22 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      {
+        source:
+          '/:slug((?!dashboard|sign-in|sign-up|discover|invite|newsletters|posts|users|settings|search|api|collectives|_next).*?)',
+        destination: '/collectives/:slug',
+        permanent: true,
+      },
+      {
+        source:
+          '/:slug((?!dashboard|sign-in|sign-up|discover|invite|newsletters|posts|users|settings|search|api|collectives|_next).*?)/:path*',
+        destination: '/collectives/:slug/:path*',
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/src/app/(editor)/posts/[postId]/edit/page.tsx
+++ b/src/app/(editor)/posts/[postId]/edit/page.tsx
@@ -1,5 +1,5 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import EditPostForm, { type PostDataType } from "./EditPostForm"; // Import the client form component
 
 export default async function EditPostPage({
@@ -12,11 +12,10 @@ export default async function EditPostPage({
 
   const {
     data: { user },
-    error: authError,
   } = await supabase.auth.getUser();
 
-  if (authError || !user) {
-    redirect("/sign-in");
+  if (!user) {
+    notFound();
   }
 
   const { data: postData, error: postFetchError } = await supabase

--- a/src/app/(editor)/posts/new/page.tsx
+++ b/src/app/(editor)/posts/new/page.tsx
@@ -1,5 +1,4 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
 import NewPostForm from "./NewPostForm";
 import { notFound } from "next/navigation";
 
@@ -16,11 +15,10 @@ export default async function NewPostPage({
   const resolvedParams = await searchParams;
   const {
     data: { user },
-    error,
   } = await supabase.auth.getUser();
 
-  if (error || !user) {
-    redirect("/sign-in");
+  if (!user) {
+    notFound();
   }
 
   let collective: { id: string; name: string; owner_id: string } | null = null;

--- a/src/app/actions/collectiveActions.ts
+++ b/src/app/actions/collectiveActions.ts
@@ -433,8 +433,8 @@ export async function updateCollectiveSettings(
   revalidatePath(`/dashboard/collectives/${collectiveId}/settings`);
   revalidatePath(`/dashboard`); // Revalidate dashboard as collective name/slug might be displayed there
   if (slug !== collective.slug) {
-    revalidatePath(`/${collective.slug}`); // Old slug path
-    revalidatePath(`/${slug}`); // New slug path
+    revalidatePath(`/collectives/${collective.slug}`); // Old slug path
+    revalidatePath(`/collectives/${slug}`); // New slug path
   }
 
   return {

--- a/src/app/actions/followActions.ts
+++ b/src/app/actions/followActions.ts
@@ -133,7 +133,7 @@ export async function followCollective(
     return { success: false, error: `Failed to follow collective: ${insertError.message}` };
   }
 
-  revalidatePath(`/${collective.slug}`);
+  revalidatePath(`/collectives/${collective.slug}`);
   revalidatePath("/");
 
   return { success: true };
@@ -177,7 +177,7 @@ export async function unfollowCollective(
   }
 
   if (collective) {
-    revalidatePath(`/${collective.slug}`);
+    revalidatePath(`/collectives/${collective.slug}`);
   }
   revalidatePath("/");
 

--- a/src/app/collectives/[slug]/[postId]/page.tsx
+++ b/src/app/collectives/[slug]/[postId]/page.tsx
@@ -42,9 +42,9 @@ export type CollectivePostViewData =
 export default async function PostPage({
   params,
 }: {
-  params: Promise<{ collectiveSlug: string; postId: string }>;
+  params: Promise<{ slug: string; postId: string }>;
 }) {
-  const { collectiveSlug, postId } = await params;
+  const { slug, postId } = await params;
   const supabase = await createServerSupabaseClient();
 
   const {
@@ -55,12 +55,12 @@ export default async function PostPage({
   const { data: collective, error: collectiveError } = await supabase
     .from('collectives')
     .select('id, name, slug, owner_id')
-    .eq('slug', collectiveSlug)
+    .eq('slug', slug)
     .single();
 
   if (collectiveError || !collective) {
     console.error(
-      `Error fetching collective ${collectiveSlug} for post ${postId}:`,
+      `Error fetching collective ${slug} for post ${postId}:`,
       collectiveError,
     );
     notFound();
@@ -84,7 +84,7 @@ export default async function PostPage({
   const post = postResult as CollectivePostViewData | null;
   if (postError || !post || !post.author) {
     console.error(
-      `Error fetching post ${postId} or author data for collective ${collectiveSlug}:`,
+      `Error fetching post ${postId} or author data for collective ${slug}:`,
       postError?.message,
     );
     notFound();

--- a/src/app/collectives/[slug]/followers/page.tsx
+++ b/src/app/collectives/[slug]/followers/page.tsx
@@ -6,15 +6,15 @@ import Link from 'next/link';
 export default async function Page({
   params,
 }: {
-  params: { collectiveSlug: string };
+  params: { slug: string };
 }) {
-  const { collectiveSlug } = params;
+  const { slug } = params;
   const supabase = await createServerSupabaseClient();
 
   const { data: collectiveData, error: collectiveError } = await supabase
     .from('collectives')
     .select('id, name')
-    .eq('slug', collectiveSlug)
+    .eq('slug', slug)
     .single();
 
   if (collectiveError || !collectiveData) {

--- a/src/app/collectives/[slug]/layout.tsx
+++ b/src/app/collectives/[slug]/layout.tsx
@@ -9,11 +9,11 @@ export default async function CollectiveLayout({
   params,
 }: {
   children: React.ReactNode;
-  params: Promise<{ collectiveSlug: string }>;
+  params: Promise<{ slug: string }>;
 }) {
-  const { collectiveSlug } = await params;
+  const { slug } = await params;
   if (process.env.NODE_ENV === "development") {
-    console.log("Rendering layout for collective slug:", collectiveSlug);
+    console.log("Rendering layout for collective slug:", slug);
   }
 
   return (

--- a/src/app/collectives/[slug]/page.tsx
+++ b/src/app/collectives/[slug]/page.tsx
@@ -15,10 +15,10 @@ export default async function Page({
   params,
   searchParams,
 }: {
-  params: { collectiveSlug: string };
+  params: { slug: string };
   searchParams: { q?: string };
 }) {
-  const { collectiveSlug } = params;
+  const { slug } = params;
   const supabase = await createServerSupabaseClient();
 
   const {
@@ -31,7 +31,7 @@ export default async function Page({
     .select(
       'id, name, description, owner_id, tags, logo_url, owner:users!owner_id(full_name)',
     )
-    .eq('slug', collectiveSlug)
+    .eq('slug', slug)
     .single();
 
   const collective = collectiveData as
@@ -42,7 +42,7 @@ export default async function Page({
 
   if (collectiveError || !collective) {
     console.error(
-      `Error fetching collective ${collectiveSlug}:`,
+      `Error fetching collective ${slug}:`,
       collectiveError,
     );
     notFound();
@@ -138,7 +138,7 @@ export default async function Page({
       like_count: p.like_count ?? 0,
       dislike_count: p.dislike_count ?? 0,
       current_user_has_liked: undefined, // Will be determined client-side
-      collective_slug: collectiveSlug,
+      collective_slug: slug,
     })) || [];
 
   const pinned =
@@ -147,7 +147,7 @@ export default async function Page({
       like_count: pinnedPost.like_count ?? 0,
       dislike_count: pinnedPost.dislike_count ?? 0,
       current_user_has_liked: undefined,
-      collective_slug: collectiveSlug,
+      collective_slug: slug,
     };
 
   type SubscriptionTier = Database['public']['Tables']['prices']['Row'];
@@ -202,7 +202,7 @@ export default async function Page({
               ? `Owned by ${collective.owner.full_name} – `
               : ''}
             <Link
-              href={`/${collectiveSlug}/followers`}
+              href={`/collectives/${slug}/followers`}
               className="hover:underline"
             >
               {followerCount ?? 0} follower

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -241,7 +241,7 @@ export default async function DashboardManagementPage() {
                     </CardHeader>
                     <CardContent className="mt-auto pt-0">
                       <Button asChild size="sm" className="w-full">
-                        <Link href={`/${collective.slug}`}>
+                        <Link href={`/collectives/${collective.slug}`}>
                           View Collective
                         </Link>
                       </Button>

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -7,11 +7,10 @@ export default async function UserSettingsPage() {
   const supabase = await createServerSupabaseClient();
   const {
     data: { user: authUser },
-    error: authError,
   } = await supabase.auth.getUser();
 
-  if (authError || !authUser) {
-    redirect('/sign-in');
+  if (!authUser) {
+    redirect('/error');
   }
 
   // Fetch user profile data

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -48,7 +48,7 @@ const dashboardNavItems = [
     icon: <UserSquare className="size-4" />,
   },
   {
-    href: '/settings',
+    href: '/dashboard/settings',
     label: 'Account Settings',
     icon: <Settings className="size-4" />,
   },
@@ -140,10 +140,10 @@ export default function Navbar() {
               <UserIcon className="size-4 mr-2" /> My Profile
             </Button>
             <Button
-              variant={pathname === '/settings' ? 'secondary' : 'ghost'}
+              variant={pathname === '/dashboard/settings' ? 'secondary' : 'ghost'}
               size="sm"
-              aria-current={pathname === '/settings' ? 'page' : undefined}
-              onClick={() => router.push('/settings')}
+              aria-current={pathname === '/dashboard/settings' ? 'page' : undefined}
+              onClick={() => router.push('/dashboard/settings')}
             >
               Account Settings
             </Button>
@@ -226,12 +226,12 @@ export default function Navbar() {
                       <UserIcon className="size-4 mr-2" /> My Profile
                     </Button>
                     <Button
-                      variant={pathname === '/settings' ? 'secondary' : 'ghost'}
+                      variant={pathname === '/dashboard/settings' ? 'secondary' : 'ghost'}
                       className="justify-start h-9 px-2"
                       aria-current={
-                        pathname === '/settings' ? 'page' : undefined
+                        pathname === '/dashboard/settings' ? 'page' : undefined
                       }
-                      onClick={() => router.push('/settings')}
+                      onClick={() => router.push('/dashboard/settings')}
                     >
                       <Settings className="size-4 mr-2" /> Account Settings
                     </Button>
@@ -289,12 +289,12 @@ export default function Navbar() {
                       <UserIcon className="size-4 mr-2" /> My Profile
                     </Button>
                     <Button
-                      variant={pathname === '/settings' ? 'secondary' : 'ghost'}
+                      variant={pathname === '/dashboard/settings' ? 'secondary' : 'ghost'}
                       className="justify-start h-9 px-2"
                       aria-current={
-                        pathname === '/settings' ? 'page' : undefined
+                        pathname === '/dashboard/settings' ? 'page' : undefined
                       }
-                      onClick={() => router.push('/settings')}
+                      onClick={() => router.push('/dashboard/settings')}
                     >
                       <Settings className="size-4 mr-2" /> Account Settings
                     </Button>

--- a/src/components/app/dashboard/collectives/CollectiveCard.tsx
+++ b/src/components/app/dashboard/collectives/CollectiveCard.tsx
@@ -24,7 +24,7 @@ export default function CollectiveCard({
     <div className="rounded-lg border bg-card text-card-foreground shadow-sm p-4 flex flex-col gap-2 hover:shadow-md transition-shadow">
       <div className="flex items-center justify-between">
         <Link
-          href={`/${collective.slug}`}
+          href={`/collectives/${collective.slug}`}
           className="text-lg font-semibold hover:text-primary"
         >
           {collective.name}

--- a/src/components/app/dashboard/collectives/DashboardCollectiveCard.tsx
+++ b/src/components/app/dashboard/collectives/DashboardCollectiveCard.tsx
@@ -57,7 +57,7 @@ export default function DashboardCollectiveCard({
       <CardHeader>
         <div className="flex justify-between items-start gap-2">
           <CardTitle className="hover:text-primary line-clamp-1 break-all">
-            <Link href={`/${collective.slug}`}>{collective.name}</Link>
+            <Link href={`/collectives/${collective.slug}`}>{collective.name}</Link>
           </CardTitle>
           <Badge
             variant={role === "Owner" ? "default" : "secondary"}
@@ -93,7 +93,7 @@ export default function DashboardCollectiveCard({
           className="flex-grow basis-1/3 sm:basis-auto"
         >
           <Link
-            href={`/${collective.slug}`}
+            href={`/collectives/${collective.slug}`}
             className="flex items-center justify-center w-full"
           >
             <Users2 className="h-4 w-4 mr-1.5" /> View

--- a/src/components/app/dashboard/organisms/SidebarNav.tsx
+++ b/src/components/app/dashboard/organisms/SidebarNav.tsx
@@ -43,7 +43,7 @@ const settingsNavItems = [
     label: "Newsletter",
   },
   {
-    href: "/settings",
+    href: "/dashboard/settings",
     icon: SettingsIcon,
     label: "Account Settings",
   },

--- a/src/components/app/profile/AudioSlider.tsx
+++ b/src/components/app/profile/AudioSlider.tsx
@@ -20,7 +20,7 @@ export default function AudioSlider({ posts }: AudioSliderProps) {
         {posts.map((post) => (
           <Link
             key={post.id}
-            href={post.collective_slug ? `/${post.collective_slug}/${post.id}` : `/posts/${post.id}`}
+            href={post.collective_slug ? `/collectives/${post.collective_slug}/${post.id}` : `/posts/${post.id}`}
             className="shrink-0 w-48 bg-card rounded-xl shadow p-3 hover:ring-2 hover:ring-primary transition"
           >
             <div className="h-24 bg-muted rounded mb-2" />


### PR DESCRIPTION
## Summary
- move collective routes under `/collectives/[slug]`
- relocate account settings to `/dashboard/settings`
- update navigation links to new routes
- redirect old collective URLs
- centralize auth checks in middleware

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
