### PR TITLE
feat: add username slug routing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,14 @@ import type { CookieOptions } from "@supabase/ssr";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  if (pathname.startsWith('/@')) {
+    const username = pathname.slice(2).split('/')[0];
+    const rest = pathname.slice(2 + username.length);
+    const url = request.nextUrl.clone();
+    url.pathname = `/profile/${username}${rest}`;
+    return NextResponse.rewrite(url);
+  }
   const requiresAuth =
     pathname.startsWith("/dashboard") ||
     pathname === "/posts/new" ||
@@ -89,6 +97,7 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    "/@:path*",
     "/dashboard/:path*",
     "/posts/:path*/edit",
     "/posts/new",

--- a/src/app/collectives/[slug]/followers/page.tsx
+++ b/src/app/collectives/[slug]/followers/page.tsx
@@ -24,7 +24,7 @@ export default async function Page({
   const { data: followersData, error: followersError } = await supabase
     .from('follows')
     .select(
-      'follower_id, follower:users!follower_id(id, full_name, avatar_url)',
+      'follower_id, follower:users!follower_id(id, username, full_name, avatar_url)',
     )
     .eq('following_id', collectiveData.id)
     .eq('following_type', 'collective');
@@ -57,7 +57,7 @@ export default async function Page({
                   />
                 )}
                 <Link
-                  href={`/users/${f.follower.id}`}
+                  href={`/@${f.follower.username}`}
                   className="hover:underline font-medium"
                 >
                   {f.follower.full_name ?? 'User'}

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -1,0 +1,255 @@
+import { createServerSupabaseClient } from '@/lib/supabase/server';
+import { notFound } from 'next/navigation';
+import ProfileFeed from '@/components/app/profile/ProfileFeed';
+import type { MicroPost } from '@/components/app/profile/MicrothreadPanel';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import SubscribeButton from '@/components/app/newsletters/molecules/SubscribeButton';
+import type { Database } from '@/lib/database.types';
+import Image from 'next/image';
+import { Badge } from '@/components/ui/badge';
+import { getSubscriptionStatus } from '@/app/actions/subscriptionActions';
+
+type PostRow = Database['public']['Tables']['posts']['Row'];
+
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: { username: string };
+  searchParams: { q?: string };
+}) {
+  const { username } = params;
+  const supabase = await createServerSupabaseClient();
+
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+
+  const { data: profile, error: profileError } = await supabase
+    .from('users')
+    .select('id, username, full_name, bio, avatar_url, tags')
+    .eq('username', username)
+    .single();
+
+  if (profileError || !profile) {
+    console.error('Error fetching user', username, profileError);
+    notFound();
+  }
+
+  const { count: followerCount } = await supabase
+    .from('follows')
+    .select('*', { count: 'exact', head: true })
+    .eq('following_id', profile.id)
+    .eq('following_type', 'user');
+
+  const { count: subscriberCount } = await supabase
+    .from('subscriptions')
+    .select('*', { count: 'exact', head: true })
+    .eq('target_entity_type', 'user')
+    .eq('target_entity_id', profile.id)
+    .eq('status', 'active');
+
+  let postsQuery = supabase
+    .from('posts')
+    .select('*')
+    .eq('author_id', profile.id)
+    .order('published_at', { ascending: false });
+
+  const { data: featuredData } = await supabase
+    .from('featured_posts')
+    .select('post_id')
+    .eq('owner_id', profile.id)
+    .eq('owner_type', 'user')
+    .maybeSingle();
+
+  let pinnedPost: PostRow | null = null;
+  if (featuredData?.post_id) {
+    const { data } = await supabase
+      .from('posts')
+      .select('*')
+      .eq('id', featuredData.post_id)
+      .maybeSingle<PostRow>();
+    if (data) pinnedPost = data;
+    postsQuery = postsQuery.neq('id', featuredData.post_id);
+  }
+
+  const isOwner = authUser?.id === profile.id;
+  const subscriptionStatus = await getSubscriptionStatus('user', profile.id);
+  const isSubscribed = subscriptionStatus?.isSubscribed;
+
+  if (isOwner) {
+    // Owners can see all their posts
+  } else if (isSubscribed) {
+    postsQuery = postsQuery.not('published_at', 'is', null);
+  } else {
+    postsQuery = postsQuery
+      .eq('is_public', true)
+      .not('published_at', 'is', null);
+  }
+
+  if (searchParams.q && searchParams.q.trim().length > 0) {
+    postsQuery = postsQuery.textSearch('tsv', searchParams.q, {
+      type: 'websearch',
+    });
+  }
+
+  const { data: postsData, error: postsError } = (await postsQuery) as {
+    data: PostRow[] | null;
+    error: unknown;
+  };
+
+  if (postsError && typeof postsError === 'object' && 'message' in postsError) {
+    console.error(
+      'Error fetching posts for user',
+      username,
+      (postsError as { message: string }).message,
+    );
+  }
+
+  const posts =
+    postsData?.map((p) => ({
+      ...p,
+      like_count: p.like_count ?? 0,
+      dislike_count: p.dislike_count ?? 0,
+      status: p.status ?? 'draft',
+      tsv: p.tsv ?? null,
+      view_count: p.view_count ?? 0,
+      published_at: p.published_at ?? null,
+      current_user_has_liked: undefined,
+    })) ?? [];
+
+  const pinned = pinnedPost && {
+    ...pinnedPost,
+    like_count: pinnedPost.like_count ?? 0,
+    dislike_count: pinnedPost.dislike_count ?? 0,
+    status: pinnedPost.status ?? 'draft',
+    tsv: pinnedPost.tsv ?? null,
+    view_count: pinnedPost.view_count ?? 0,
+    published_at: pinnedPost.published_at ?? null,
+    current_user_has_liked: undefined,
+  };
+
+  const microPosts: MicroPost[] = [
+    { id: 'u1', content: 'Thanks for checking out my work!' },
+    { id: 'u2', content: 'New article coming soon.' },
+    { id: 'u3', content: 'Follow me for updates!' },
+  ];
+
+  type SubscriptionTier = Database['public']['Tables']['prices']['Row'];
+  let tiers: SubscriptionTier[] = [];
+  const defaultPriceId = process.env.NEXT_PUBLIC_STRIPE_DEFAULT_PRICE_ID;
+  if (defaultPriceId) {
+    const { data: price } = (await supabase
+      .from('prices')
+      .select('id, unit_amount, currency, interval, description')
+      .eq('id', defaultPriceId)
+      .maybeSingle()) as { data: SubscriptionTier | null };
+    if (price) tiers = [price];
+  }
+
+  return (
+    <div className="container mx-auto p-4 md:p-6">
+      <header className="mb-8 pb-6 border-b border-primary/10 flex flex-col items-center">
+        <div className="flex flex-col items-center gap-2 mb-4">
+          {profile.avatar_url && (
+            <Image
+              src={profile.avatar_url}
+              alt={`${profile.full_name ?? 'User'} avatar`}
+              width={160}
+              height={160}
+              className="rounded-full object-cover"
+            />
+          )}
+          <h1 className="text-5xl font-extrabold tracking-tight text-center">
+            {profile.full_name ?? 'User'}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            <Link
+              href={`/@${profile.username}/followers`}
+              className="hover:underline"
+            >
+              {followerCount ?? 0} follower
+              {(followerCount ?? 0) === 1 ? '' : 's'}
+            </Link>{' '}
+            – {subscriberCount ?? 0} subscriber
+            {(subscriberCount ?? 0) === 1 ? '' : 's'}
+          </p>
+          {profile.tags && profile.tags.length > 0 && (
+            <div className="flex flex-wrap justify-center gap-1 mt-1">
+              {profile.tags.map((tag) => (
+                <Badge key={tag} variant="secondary">
+                  #{tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+        {profile.bio && (
+          <div className="bg-card shadow rounded-xl p-6 max-w-2xl w-full text-center mx-auto">
+            <p className="text-lg text-muted-foreground">{profile.bio}</p>
+          </div>
+        )}
+        <div className="mt-4 w-full max-w-md">
+          <form action="" className="flex items-center gap-2">
+            <input
+              type="search"
+              name="q"
+              placeholder="Search this profile..."
+              className="w-full px-3 py-2 border border-border rounded-md bg-background text-sm"
+            />
+            <Button type="submit" size="sm" variant="outline">
+              Search
+            </Button>
+          </form>
+        </div>
+        {isOwner ? (
+          <div className="mt-4">
+            <Button asChild variant="outline">
+              <Link href="/dashboard/profile/edit">Edit Profile</Link>
+            </Button>
+          </div>
+        ) : (
+          <div className="mt-4">
+            <SubscribeButton
+              targetEntityType="user"
+              targetEntityId={profile.id}
+              targetName={profile.full_name ?? ''}
+              tiers={tiers}
+            />
+          </div>
+        )}
+      </header>
+
+      <main>
+        {posts && posts.length > 0 ? (
+          <ProfileFeed
+            posts={posts}
+            pinnedPost={pinned ?? undefined}
+            microPosts={microPosts}
+          />
+        ) : (
+          <div className="text-center py-10">
+            {searchParams.q ? (
+              <>
+                <h2 className="text-2xl font-semibold mb-2">
+                  No posts found for your search.
+                </h2>
+                <p className="text-muted-foreground">
+                  Try a different search term.
+                </p>
+              </>
+            ) : (
+              <>
+                <h2 className="text-2xl font-semibold mb-2">No posts yet!</h2>
+                <p className="text-muted-foreground">
+                  This user hasn&apos;t published any posts. Check back later!
+                </p>
+              </>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -59,7 +59,7 @@ export default async function Page({
 
     const { data: usersData } = await supabase
       .from('users')
-      .select('id, full_name, bio, avatar_url')
+      .select('id, username, full_name, bio, avatar_url')
       .textSearch('tsv', q, { type: 'websearch' })
       .limit(10);
 
@@ -119,7 +119,7 @@ export default async function Page({
             {users.map((u) => (
               <li key={u.id} className="">
                 <Link
-                  href={`/users/${u.id}`}
+                  href={`/@${u.username}`}
                   className="font-medium text-primary hover:underline"
                 >
                   {u.full_name || 'Unnamed User'}

--- a/src/app/users/[userId]/followers/page.tsx
+++ b/src/app/users/[userId]/followers/page.tsx
@@ -9,7 +9,7 @@ export default async function Page({ params }: { params: { userId: string } }) {
 
   const { data: profile, error: profileError } = await supabase
     .from('users')
-    .select('id, full_name')
+    .select('id, username, full_name')
     .eq('id', userId)
     .single();
 
@@ -20,7 +20,7 @@ export default async function Page({ params }: { params: { userId: string } }) {
   const { data: followersData, error: followersError } = await supabase
     .from('follows')
     .select(
-      'follower_id, follower:users!follower_id(id, full_name, avatar_url)',
+      'follower_id, follower:users!follower_id(id, username, full_name, avatar_url)',
     )
     .eq('following_id', userId)
     .eq('following_type', 'user');
@@ -53,7 +53,7 @@ export default async function Page({ params }: { params: { userId: string } }) {
                   />
                 )}
                 <Link
-                  href={`/users/${f.follower.id}`}
+                  href={`/@${f.follower.username}`}
                   className="hover:underline font-medium"
                 >
                   {f.follower.full_name ?? 'User'}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -58,20 +58,39 @@ export default function Navbar() {
   const router = useRouter();
   const pathname = usePathname();
   const [user, setUser] = useState<User | null>(null);
+  const [username, setUsername] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
     // Fetch current user using shared Supabase client
     supabase.auth
       .getUser()
-      .then(({ data }: { data: { user: User | null } }) => {
+      .then(async ({ data }: { data: { user: User | null } }) => {
         setUser(data.user);
+        if (data.user) {
+          const { data: profile } = await supabase
+            .from('users')
+            .select('username')
+            .eq('id', data.user.id)
+            .single();
+          setUsername(profile?.username ?? null);
+        }
         setIsLoading(false);
       });
     // Subscribe to auth changes on the singleton client
     const { data: authListener } = supabase.auth.onAuthStateChange(
-      (event: string, session: Session | null) => {
+      async (event: string, session: Session | null) => {
         setUser(session?.user ?? null);
+        if (session?.user) {
+          const { data: profile } = await supabase
+            .from('users')
+            .select('username')
+            .eq('id', session.user.id)
+            .single();
+          setUsername(profile?.username ?? null);
+        } else {
+          setUsername(null);
+        }
         // Sync session to server cookie on sign-in/sign-out
         fetch('/api/auth/callback', {
           method: 'POST',
@@ -129,13 +148,13 @@ export default function Navbar() {
             </Button>
             <Button
               variant={
-                pathname === `/users/${user?.id}` ? 'secondary' : 'ghost'
+                pathname === `/@${username}` ? 'secondary' : 'ghost'
               }
               size="sm"
               aria-current={
-                pathname === `/users/${user?.id}` ? 'page' : undefined
+                pathname === `/@${username}` ? 'page' : undefined
               }
-              onClick={() => router.push(`/users/${user?.id}`)}
+              onClick={() => router.push(`/@${username ?? user?.id}`)}
             >
               <UserIcon className="size-4 mr-2" /> My Profile
             </Button>
@@ -213,15 +232,15 @@ export default function Navbar() {
                     ))}
                     <Button
                       variant={
-                        pathname === `/users/${user?.id}`
+                        pathname === `/@${username}`
                           ? 'secondary'
                           : 'ghost'
                       }
                       className="justify-start h-9 px-2"
                       aria-current={
-                        pathname === `/users/${user?.id}` ? 'page' : undefined
+                        pathname === `/@${username}` ? 'page' : undefined
                       }
-                      onClick={() => router.push(`/users/${user?.id}`)}
+                      onClick={() => router.push(`/@${username ?? user?.id}`)}
                     >
                       <UserIcon className="size-4 mr-2" /> My Profile
                     </Button>
@@ -276,15 +295,15 @@ export default function Navbar() {
                     </Button>
                     <Button
                       variant={
-                        pathname === `/users/${user?.id}`
+                        pathname === `/@${username}`
                           ? 'secondary'
                           : 'ghost'
                       }
                       className="justify-start h-9 px-2"
                       aria-current={
-                        pathname === `/users/${user?.id}` ? 'page' : undefined
+                        pathname === `/@${username}` ? 'page' : undefined
                       }
-                      onClick={() => router.push(`/users/${user?.id}`)}
+                      onClick={() => router.push(`/@${username ?? user?.id}`)}
                     >
                       <UserIcon className="size-4 mr-2" /> My Profile
                     </Button>

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -593,6 +593,7 @@ export type Database = {
           created_at: string
           dislike_count: number | null
           id: string
+          slug: string | null
           is_public: boolean
           like_count: number
           published_at: string | null
@@ -608,6 +609,7 @@ export type Database = {
           created_at?: string
           dislike_count?: number | null
           id?: string
+          slug?: string | null
           is_public?: boolean
           like_count?: number
           published_at?: string | null
@@ -623,6 +625,7 @@ export type Database = {
           created_at?: string
           dislike_count?: number | null
           id?: string
+          slug?: string | null
           is_public?: boolean
           like_count?: number
           published_at?: string | null
@@ -893,6 +896,7 @@ export type Database = {
           bio: string | null
           cover_image_url: string | null
           embedding: string | null
+          username: string | null
           full_name: string | null
           id: string
           is_profile_public: boolean | null
@@ -915,6 +919,7 @@ export type Database = {
           bio?: string | null
           cover_image_url?: string | null
           embedding?: string | null
+          username?: string | null
           full_name?: string | null
           id: string
           is_profile_public?: boolean | null
@@ -937,6 +942,7 @@ export type Database = {
           bio?: string | null
           cover_image_url?: string | null
           embedding?: string | null
+          username?: string | null
           full_name?: string | null
           id?: string
           is_profile_public?: boolean | null

--- a/supabase/migrations/add_username_and_post_slug.sql
+++ b/supabase/migrations/add_username_and_post_slug.sql
@@ -1,0 +1,6 @@
+-- Migration: Add username to users and slug to posts
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS username text UNIQUE;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON public.users(username);
+
+ALTER TABLE public.posts ADD COLUMN IF NOT EXISTS slug text UNIQUE;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_posts_slug ON public.posts(slug);


### PR DESCRIPTION
## Summary
- add new migration for `username` on users and `slug` on posts
- map `/@username` paths to profile pages via middleware
- implement new profile route `profile/[username]`
- link to usernames in search results and follower lists
- fetch username in Navbar and update profile links

## Testing
- `pnpm test`