### PR TITLE
Add editor layout and editor column styles

### DIFF
--- a/src/app/(editor)/layout.tsx
+++ b/src/app/(editor)/layout.tsx
@@ -1,3 +1,4 @@
+import Navbar from '@/components/Navbar';
 import React from 'react';
 
 export default function EditorLayout({
@@ -5,5 +6,20 @@ export default function EditorLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      <header className="bg-background border-b border-border py-4 px-4 md:px-6 sticky top-0 z-50">
+        <div className="container mx-auto flex items-center justify-between">
+          <span className="text-2xl md:text-3xl font-serif font-extrabold text-foreground tracking-tight flex items-center">
+            Lnked
+            <span className="ml-1 text-primary text-3xl md:text-4xl leading-none self-center" aria-hidden="true">
+              .
+            </span>
+          </span>
+          <Navbar />
+        </div>
+      </header>
+      <main className="flex-1 container mx-auto px-4 md:px-6 py-8">{children}</main>
+    </>
+  );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -427,3 +427,20 @@
 body {
   height: 100%;
 }
+
+/* Editor Columns Layout */
+.layout-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .layout-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.layout-item {
+  /* acts as a column */
+}


### PR DESCRIPTION
## Summary
- show main header and navbar on editor pages
- enable two-column layout styles for editor

## Testing
- `pnpm lint` *(fails: 'authorId' is defined but never used, etc.)*
- `pnpm typecheck`
- `pnpm test`
