### PR TITLE
Enable multi-column post layout

### DIFF
--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -88,7 +88,7 @@ export default async function PostBySlugPage({
   }
 
   return (
-    <div className="container mx-auto max-w-3xl p-4 md:p-6">
+    <div className="container mx-auto max-w-3xl xl:max-w-6xl p-4 md:p-6">
       <PostViewTracker postId={post!.id} />
       <nav
         aria-label="Breadcrumb"
@@ -166,7 +166,7 @@ export default async function PostBySlugPage({
             />
           </div>
         </header>
-        <div className="prose dark:prose-invert lg:prose-xl max-w-none">
+        <div className="prose dark:prose-invert lg:prose-xl max-w-none xl:columns-2 xl:gap-8 column-balance">
           <LexicalRenderer contentJSON={post!.content ?? ''} />
         </div>
       </article>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -444,3 +444,13 @@ body {
 .layout-item {
   /* acts as a column */
 }
+
+/* Multi-column reading layout utilities */
+.column-balance {
+  column-fill: balance;
+}
+
+.prose {
+  hyphens: auto;
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
## Summary
- widen post container on xl screens
- flow article text into two columns
- balance columns and enable hyphenation

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm typecheck`
- `pnpm test`