### PR TITLE
Improve Navbar semantics and add skip links

### DIFF
--- a/src/app/(editor)/layout.tsx
+++ b/src/app/(editor)/layout.tsx
@@ -1,25 +1,55 @@
 import Navbar from '@/components/Navbar';
 import React from 'react';
+import { createServerSupabaseClient } from '@/lib/supabase/server';
 
-export default function EditorLayout({
+export default async function EditorLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let username: string | null = null;
+  if (user) {
+    const { data: profile } = await supabase
+      .from('users')
+      .select('username')
+      .eq('id', user.id)
+      .single();
+    username = profile?.username ?? null;
+  }
+
   return (
     <>
+      <a
+        href="#editor-main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-accent text-accent-foreground p-2 rounded"
+      >
+        Skip to main content
+      </a>
       <header className="bg-background border-b border-border py-4 px-4 md:px-6 sticky top-0 z-50">
         <div className="container mx-auto flex items-center justify-between">
           <span className="text-2xl md:text-3xl font-serif font-extrabold text-foreground tracking-tight flex items-center">
             Lnked
-            <span className="ml-1 text-accent text-3xl md:text-4xl leading-none self-center" aria-hidden="true">
+            <span
+              className="ml-1 text-accent text-3xl md:text-4xl leading-none self-center"
+              aria-hidden="true"
+            >
               .
             </span>
           </span>
-          <Navbar />
+          <Navbar initialUser={user} initialUsername={username} />
         </div>
       </header>
-      <main className="flex-1 container mx-auto px-4 md:px-6 py-8">{children}</main>
+      <main
+        id="editor-main-content"
+        className="flex-1 container mx-auto px-4 md:px-6 py-8"
+      >
+        {children}
+      </main>
     </>
   );
 }

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,22 +1,56 @@
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/ui/Footer';
 import React from 'react';
+import { createServerSupabaseClient } from '@/lib/supabase/server';
 
-export default function PublicLayout({ children }: { children: React.ReactNode }) {
+export default async function PublicLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let username: string | null = null;
+  if (user) {
+    const { data: profile } = await supabase
+      .from('users')
+      .select('username')
+      .eq('id', user.id)
+      .single();
+    username = profile?.username ?? null;
+  }
+
   return (
     <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-accent text-accent-foreground p-2 rounded"
+      >
+        Skip to main content
+      </a>
       <header className="bg-background border-b border-border py-4 px-4 md:px-6 sticky top-0 z-50">
         <div className="container mx-auto flex items-center justify-between">
           <span className="text-2xl md:text-3xl font-serif font-extrabold text-foreground tracking-tight flex items-center">
             Lnked
-            <span className="ml-1 text-accent text-3xl md:text-4xl leading-none self-center" aria-hidden="true">
+            <span
+              className="ml-1 text-accent text-3xl md:text-4xl leading-none self-center"
+              aria-hidden="true"
+            >
               .
             </span>
           </span>
-          <Navbar />
+          <Navbar initialUser={user} initialUsername={username} />
         </div>
       </header>
-      <main className="flex-1 container mx-auto px-4 md:px-6 py-8">{children}</main>
+      <main
+        id="main-content"
+        className="flex-1 container mx-auto px-4 md:px-6 py-8"
+      >
+        {children}
+      </main>
       <Footer />
     </>
   );

--- a/src/components/app/dashboard/organisms/DashboardShell.tsx
+++ b/src/components/app/dashboard/organisms/DashboardShell.tsx
@@ -23,6 +23,12 @@ export default function DashboardShell({
 
   return (
     <div className="flex flex-col min-h-screen h-full bg-background text-foreground">
+      <a
+        href="#dashboard-main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-accent text-accent-foreground p-2 rounded z-50"
+      >
+        Skip to main content
+      </a>
       <DashboardNav
         sidebarCollapsed={sidebarCollapsed}
         onToggleSidebar={() => setSidebarCollapsed((c) => !c)}
@@ -34,7 +40,12 @@ export default function DashboardShell({
           collectives={userCollectives}
           collapsed={sidebarCollapsed}
         />
-        <main className="flex-1 overflow-y-auto p-4 md:p-6">{children}</main>
+        <main
+          id="dashboard-main-content"
+          className="flex-1 overflow-y-auto p-4 md:p-6"
+        >
+          {children}
+        </main>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace router pushes in Navbar with `Link` components
- fetch user info server-side and pass to Navbar
- add skip to content links for public, editor, and dashboard layouts

## Testing
- `pnpm lint` *(fails: 'authorId' defined but never used, etc.)*
- `pnpm typecheck`
- `pnpm test`
