### PR TITLE
Fix auth header and link navbar logo

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import React from 'react';
 
 export default function AuthLayout({
@@ -8,22 +7,6 @@ export default function AuthLayout({
 }) {
   return (
     <div className="flex min-h-screen flex-col">
-      <header className="border-b border-border py-4 px-4 md:px-6">
-        <div className="container mx-auto flex items-center justify-center">
-          <Link
-            href="/"
-            className="text-2xl font-serif font-extrabold tracking-tight text-foreground"
-          >
-            Lnked
-            <span
-              className="ml-1 text-accent text-3xl leading-none"
-              aria-hidden="true"
-            >
-              .
-            </span>
-          </Link>
-        </div>
-      </header>
       <main className="flex-1 container mx-auto flex items-center justify-center px-4 md:px-6 py-8">
         {children}
       </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import SmoothScroll from '@/components/app/SmoothScroll';
 import RouteProgress from '@/components/app/nav/RouteProgress';
 import Navbar from '@/components/Navbar';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Lnked - Collaborative Newsletters',
@@ -55,7 +56,10 @@ export default async function RootLayout({
           {/* Global site header */}
           <header className="bg-background border-b border-border py-4 px-4 md:px-6 sticky top-0 z-50">
             <div className="container mx-auto flex items-center justify-between">
-              <span className="text-2xl md:text-3xl font-serif font-extrabold text-foreground tracking-tight flex items-center">
+              <Link
+                href="/dashboard"
+                className="text-2xl md:text-3xl font-serif font-extrabold text-foreground tracking-tight flex items-center"
+              >
                 Lnked
                 <span
                   className="ml-1 text-accent text-3xl md:text-4xl leading-none self-center"
@@ -63,7 +67,7 @@ export default async function RootLayout({
                 >
                   .
                 </span>
-              </span>
+              </Link>
               <Navbar initialUser={user} initialUsername={username} />
             </div>
           </header>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -125,9 +125,16 @@ export default function Navbar({ initialUser, initialUsername }: NavbarProps) {
     setIsLoading(false);
   };
 
-  // Hide Navbar on auth pages or specific routes if desired
-  if (pathname === '/sign-in' || pathname === '/sign-up') {
-    return null;
+  const isAuthPage = pathname === '/sign-in' || pathname === '/sign-up';
+
+  if (isAuthPage) {
+    return (
+      <nav className="flex items-center justify-end gap-2 md:gap-4">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/">Back</Link>
+        </Button>
+      </nav>
+    );
   }
 
   const isDashboardPath = pathname.startsWith('/dashboard');


### PR DESCRIPTION
## Summary
- drop redundant header from auth layout
- make site logo link to the dashboard
- show a Back link in the navbar on auth pages

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: column 'username' does not exist)*
- `pnpm test`