### PR TITLE
Improve editorial typography

### DIFF
--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -166,7 +166,7 @@ export default async function PostBySlugPage({
             />
           </div>
         </header>
-        <div className="prose dark:prose-invert lg:prose-xl max-w-none xl:columns-2 xl:gap-8 column-balance">
+        <div className="prose dark:prose-invert lg:prose-xl 2xl:prose-2xl max-w-none xl:columns-2 xl:gap-8 column-balance">
           <LexicalRenderer contentJSON={post!.content ?? ''} />
         </div>
       </article>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -454,3 +454,13 @@ body {
   hyphens: auto;
   overflow-wrap: break-word;
 }
+
+.prose img {
+  break-inside: avoid;
+}
+
+.prose pre {
+  white-space: pre-wrap;
+  overflow-x: auto;
+  break-inside: avoid;
+}

--- a/src/components/ui/LexicalRenderer.tsx
+++ b/src/components/ui/LexicalRenderer.tsx
@@ -39,7 +39,7 @@ export function LexicalRenderer({ contentJSON }: LexicalRendererProps) {
     const htmlString = typeof contentJSON === 'string' ? contentJSON : '';
     return (
       <div
-        className="prose dark:prose-invert lg:prose-xl max-w-none"
+        className="prose dark:prose-invert lg:prose-xl 2xl:prose-2xl max-w-none"
         dangerouslySetInnerHTML={{ __html: htmlString }}
       />
     );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -87,22 +87,31 @@ const config: Config = {
               fontFamily: theme("fontFamily.serif"),
               fontSize: "1.125rem",
               lineHeight: "1.6",
+              marginTop: "1.25em",
+              marginBottom: "1.25em",
             },
             h1: {
               color: "hsl(var(--foreground))",
               fontFamily: theme("fontFamily.serif"),
+              marginTop: "1.5em",
+              marginBottom: "0.5em",
             },
             h2: {
               color: "hsl(var(--foreground))",
               fontFamily: theme("fontFamily.serif"),
+              marginTop: "1.25em",
+              marginBottom: "0.5em",
             },
             h3: {
               color: "hsl(var(--foreground))",
               fontFamily: theme("fontFamily.serif"),
+              marginTop: "1em",
+              marginBottom: "0.5em",
             },
             blockquote: {
               color: "hsl(var(--muted-foreground))",
-              borderLeftColor: "hsl(var(--border))",
+              borderLeftColor: "hsl(var(--accent))",
+              fontStyle: "italic",
             },
             code: {
               color: "hsl(var(--foreground))",
@@ -116,6 +125,8 @@ const config: Config = {
               fontFamily: theme("fontFamily.serif"),
               fontSize: "1.125rem",
               lineHeight: "1.6",
+              marginTop: "1.25em",
+              marginBottom: "1.25em",
             },
             color: "hsl(var(--foreground))",
             a: {
@@ -126,12 +137,21 @@ const config: Config = {
             },
             blockquote: {
               color: "hsl(var(--muted-foreground))",
-              borderLeftColor: "hsl(var(--border))",
+              borderLeftColor: "hsl(var(--accent))",
+              fontStyle: "italic",
             },
             code: {
               color: "hsl(var(--foreground))",
               backgroundColor: "hsl(var(--muted))",
             },
+          },
+        },
+        "2xl": {
+          css: {
+            p: { fontSize: "1.25rem", lineHeight: "1.7" },
+            h1: { fontSize: "2.5rem" },
+            h2: { fontSize: "2rem" },
+            h3: { fontSize: "1.75rem" },
           },
         },
       }),


### PR DESCRIPTION
## Summary
- tweak typography plugin for consistent spacing and larger `2xl` size
- keep code blocks and images from breaking columns
- highlight blockquotes with accent color
- enlarge article fonts on wide screens

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck` *(fails: Property 'slug' does not exist on type ... )*