### PR TITLE
Fix post slug handling for view and interactions

### DIFF
--- a/src/app/(editor)/posts/[slug]/edit/EditPostForm.tsx
+++ b/src/app/(editor)/posts/[slug]/edit/EditPostForm.tsx
@@ -26,7 +26,7 @@ export interface PostDataType extends Tables<'posts'> {
 }
 
 interface EditPostFormProps {
-  slug: string;
+  postId: string;
   initialData: PostDataType;
   pageTitle: string;
 }
@@ -69,7 +69,7 @@ const EMPTY_LEXICAL_STATE = JSON.stringify({
 });
 
 export default function EditPostForm({
-  slug,
+  postId,
   initialData,
   pageTitle,
 }: EditPostFormProps) {
@@ -133,14 +133,14 @@ export default function EditPostForm({
           ? new Date(dataToSave.published_at).toISOString()
           : null,
     };
-    const result = await updatePost(slug, autosavePayload);
+    const result = await updatePost(postId, autosavePayload);
     if (result.error) {
       setAutosaveStatus(`Autosave failed: ${result.error.substring(0, 100)}`);
     } else {
       setAutosaveStatus('Draft saved.');
       reset(dataToSave); // Reset dirty state with current values
     }
-  }, [isDirty, currentStatus, getValues, slug, reset]);
+  }, [isDirty, currentStatus, getValues, postId, reset]);
 
   useEffect(() => {
     const isDrafting = currentStatus === 'draft';
@@ -181,7 +181,7 @@ export default function EditPostForm({
     }
 
     startTransition(async () => {
-      const result = await updatePost(slug, payloadForUpdate);
+      const result = await updatePost(postId, payloadForUpdate);
       if (result.error) {
         setServerError(result.error);
       } else if (result.data) {
@@ -203,7 +203,7 @@ export default function EditPostForm({
     setServerError(null);
     setAutosaveStatus('');
     startTransition(async () => {
-      const result = await deletePost(slug);
+      const result = await deletePost(postId);
       if (result.error) {
         setServerError(result.error);
         setIsDeleting(false);

--- a/src/app/(editor)/posts/[slug]/edit/page.tsx
+++ b/src/app/(editor)/posts/[slug]/edit/page.tsx
@@ -81,7 +81,7 @@ export default async function EditPostPage({
 
   return (
     <EditPostForm
-      slug={slug}
+      postId={postData.id}
       initialData={initialPostData}
       pageTitle={pageTitle}
     />

--- a/src/app/(public)/posts/[slug]/page.tsx
+++ b/src/app/(public)/posts/[slug]/page.tsx
@@ -28,6 +28,7 @@ function calculateReadingTime(htmlContent: string | null): string {
 }
 
 type PostViewData = Database['public']['Tables']['posts']['Row'] & {
+  slug: string | null;
   author: {
     id: string;
     full_name: string | null;
@@ -171,14 +172,14 @@ export default async function PostBySlugPage({
           </div>
           <div className="mt-4 flex flex-row gap-4 justify-center items-center">
             <PostReactionButtons
-              postId={post!.id}
+              postSlug={post!.slug!}
               initialLikeCount={initialLikeCount}
               initialDislikeCount={initialDislikeCount}
               initialUserReaction={initialUserReaction}
               disabled={!user?.id}
             />
             <BookmarkButton
-              postId={post!.id}
+              postSlug={post!.slug!}
               initialBookmarked={initialBookmarked}
               disabled={!user?.id}
             />
@@ -193,11 +194,14 @@ export default async function PostBySlugPage({
         <div className="flex justify-between items-center">
           {isOwner && (
             <Button asChild variant="outline">
-              <Link href={`/posts/${post!.id}/edit`}>Edit Post</Link>
+              <Link href={`/posts/${post!.slug}/edit`}>Edit Post</Link>
             </Button>
           )}
         </div>
-        <CommentsSection postId={post!.id} currentUserId={user?.id ?? null} />
+        <CommentsSection
+          postSlug={post!.slug!}
+          currentUserId={user?.id ?? null}
+        />
       </footer>
     </div>
   );

--- a/src/components/app/dashboard/posts/PostListItem.tsx
+++ b/src/components/app/dashboard/posts/PostListItem.tsx
@@ -1,16 +1,17 @@
-"use client";
+'use client';
 
-import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Edit, Eye, Trash2, Pin, PinOff } from "lucide-react";
-import { useTransition } from "react";
-import { deletePost, featurePost } from "@/app/actions/postActions";
-import { useRouter } from "next/navigation";
-import type { Database } from "@/lib/database.types";
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Edit, Eye, Trash2, Pin, PinOff } from 'lucide-react';
+import { useTransition } from 'react';
+import { deletePost, featurePost } from '@/app/actions/postActions';
+import { useRouter } from 'next/navigation';
+import type { Database } from '@/lib/database.types';
 
-type PostRow = Database["public"]["Tables"]["posts"]["Row"];
+type PostRow = Database['public']['Tables']['posts']['Row'];
 interface DashboardPost extends PostRow {
+  slug?: string | null;
   collective?: { id: string; name: string; slug: string } | null;
   likes?: { count: number }[] | null;
   post_reactions?: { count: number; type?: string }[] | null;
@@ -23,10 +24,10 @@ interface PostListItemProps {
 }
 
 function getStatus(post: DashboardPost) {
-  if (!post.published_at) return "Draft";
+  if (!post.published_at) return 'Draft';
   if (post.published_at && new Date(post.published_at) > new Date())
-    return "Scheduled";
-  return "Published";
+    return 'Scheduled';
+  return 'Published';
 }
 
 export default function PostListItem({ post }: PostListItemProps) {
@@ -34,18 +35,22 @@ export default function PostListItem({ post }: PostListItemProps) {
   const router = useRouter();
   const status = getStatus(post);
   const statusColor =
-    status === "Draft"
-      ? "outline"
-      : status === "Scheduled"
-      ? "secondary"
-      : "default";
+    status === 'Draft'
+      ? 'outline'
+      : status === 'Scheduled'
+        ? 'secondary'
+        : 'default';
   const likes =
-    typeof post.likeCount === "number"
+    typeof post.likeCount === 'number'
       ? post.likeCount
       : post.likes?.[0]?.count || post.post_reactions?.[0]?.count || 0;
   const publishDate = post.published_at || post.created_at;
-  const postUrl = post.slug ? `/posts/${post.slug}` : (post.collective ? `/collectives/${post.collective.slug}/${post.id}` : `/posts/${post.id}`);
-  const editUrl = `/posts/${post.id}/edit`;
+  const postUrl = post.slug
+    ? `/posts/${post.slug}`
+    : post.collective
+      ? `/collectives/${post.collective.slug}/${post.id}`
+      : `/posts/${post.id}`;
+  const editUrl = `/posts/${post.slug}/edit`;
 
   const handleToggleFeature = () => {
     startTransition(async () => {
@@ -55,7 +60,7 @@ export default function PostListItem({ post }: PostListItemProps) {
   };
 
   const handleDelete = () => {
-    if (window.confirm("Are you sure you want to delete this post?")) {
+    if (window.confirm('Are you sure you want to delete this post?')) {
       startTransition(async () => {
         await deletePost(post.id);
         router.refresh();
@@ -83,7 +88,7 @@ export default function PostListItem({ post }: PostListItemProps) {
         </Badge>
       </td>
       <td className="px-4 py-2">
-        {publishDate ? new Date(publishDate).toLocaleDateString() : "N/A"}
+        {publishDate ? new Date(publishDate).toLocaleDateString() : 'N/A'}
       </td>
       <td className="px-4 py-2 tabular-nums">{likes}</td>
       <td className="px-4 py-2">
@@ -98,11 +103,11 @@ export default function PostListItem({ post }: PostListItemProps) {
               <Edit className="h-4 w-4" />
             </Link>
           </Button>
-          {status === "Published" && (
+          {status === 'Published' && (
             <Button
               variant="ghost"
               size="icon"
-              aria-label={post.isFeatured ? "Unpin post" : "Pin post"}
+              aria-label={post.isFeatured ? 'Unpin post' : 'Pin post'}
               onClick={handleToggleFeature}
               disabled={isPending}
             >

--- a/src/components/app/editor/sidebar/FileExplorer.tsx
+++ b/src/components/app/editor/sidebar/FileExplorer.tsx
@@ -1,16 +1,16 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { ChevronDown, ChevronRight, Plus } from "lucide-react";
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ChevronDown, ChevronRight, Plus } from 'lucide-react';
 
 export interface FileExplorerProps {
-  personalPosts: { id: string; title: string; status: string }[];
+  personalPosts: { id: string; slug: string; title: string; status: string }[];
   collectives: {
     id: string;
     name: string;
-    posts: { id: string; title: string; status: string }[];
+    posts: { id: string; slug: string; title: string; status: string }[];
   }[];
 }
 
@@ -47,13 +47,13 @@ export function FileExplorer({
           {personalPosts.map((post) => (
             <li key={post.id}>
               <Link
-                href={`/posts/${post.id}/edit`}
+                href={`/posts/${post.slug}/edit`}
                 className={`block px-2 py-1 rounded-md transition-colors text-sm ${
                   isActive(post.id)
-                    ? "bg-sidebar-accent/10 text-sidebar-accent font-medium"
-                    : "text-sidebar-foreground/80 hover:bg-sidebar-accent/5 hover:text-sidebar-foreground"
+                    ? 'bg-sidebar-accent/10 text-sidebar-accent font-medium'
+                    : 'text-sidebar-foreground/80 hover:bg-sidebar-accent/5 hover:text-sidebar-foreground'
                 }`}
-                aria-current={isActive(post.id) ? "page" : undefined}
+                aria-current={isActive(post.id) ? 'page' : undefined}
               >
                 {post.title}
               </Link>
@@ -112,13 +112,13 @@ export function FileExplorer({
                     {col.posts.map((post) => (
                       <li key={post.id}>
                         <Link
-                          href={`/posts/${post.id}/edit`}
+                          href={`/posts/${post.slug}/edit`}
                           className={`block px-2 py-1 rounded-md transition-colors text-sm ${
                             isActive(post.id)
-                              ? "bg-sidebar-accent/10 text-sidebar-accent font-medium"
-                              : "text-sidebar-foreground/80 hover:bg-sidebar-accent/5 hover:text-sidebar-foreground"
+                              ? 'bg-sidebar-accent/10 text-sidebar-accent font-medium'
+                              : 'text-sidebar-foreground/80 hover:bg-sidebar-accent/5 hover:text-sidebar-foreground'
                           }`}
-                          aria-current={isActive(post.id) ? "page" : undefined}
+                          aria-current={isActive(post.id) ? 'page' : undefined}
                         >
                           {post.title}
                         </Link>

--- a/src/components/app/posts/molecules/BookmarkButton.tsx
+++ b/src/components/app/posts/molecules/BookmarkButton.tsx
@@ -1,17 +1,17 @@
-"use client";
+'use client';
 
-import { useState, useTransition } from "react";
-import { Button } from "@/components/ui/button";
-import { Bookmark, BookmarkCheck } from "lucide-react";
+import { useState, useTransition } from 'react';
+import { Button } from '@/components/ui/button';
+import { Bookmark, BookmarkCheck } from 'lucide-react';
 
 interface BookmarkButtonProps {
-  postId: string;
+  postSlug: string;
   initialBookmarked: boolean;
   disabled?: boolean;
 }
 
 export default function BookmarkButton({
-  postId,
+  postSlug,
   initialBookmarked,
   disabled = false,
 }: BookmarkButtonProps) {
@@ -23,9 +23,9 @@ export default function BookmarkButton({
     const prevBookmarked = bookmarked;
     setBookmarked(!bookmarked);
     startTransition(async () => {
-      const res = await fetch(`/api/posts/${postId}/bookmark`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      const res = await fetch(`/api/posts/${postSlug}/bookmark`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
       });
       if (res.ok) {
         const data = await res.json();
@@ -38,9 +38,9 @@ export default function BookmarkButton({
 
   return (
     <Button
-      variant={bookmarked ? "default" : "ghost"}
+      variant={bookmarked ? 'default' : 'ghost'}
       size="icon"
-      aria-label={bookmarked ? "Remove bookmark" : "Bookmark post"}
+      aria-label={bookmarked ? 'Remove bookmark' : 'Bookmark post'}
       onClick={handleToggle}
       disabled={disabled || isPending}
       className="rounded-full"

--- a/src/components/app/posts/molecules/PostReactionButtons.tsx
+++ b/src/components/app/posts/molecules/PostReactionButtons.tsx
@@ -1,19 +1,19 @@
-"use client";
+'use client';
 
-import { useState, useTransition } from "react";
-import { Button } from "@/components/ui/button";
-import { ThumbsUp, ThumbsDown } from "lucide-react";
+import { useState, useTransition } from 'react';
+import { Button } from '@/components/ui/button';
+import { ThumbsUp, ThumbsDown } from 'lucide-react';
 
 interface PostReactionButtonsProps {
-  postId: string;
+  postSlug: string;
   initialLikeCount: number;
   initialDislikeCount: number;
-  initialUserReaction: "like" | "dislike" | null;
+  initialUserReaction: 'like' | 'dislike' | null;
   disabled?: boolean;
 }
 
 export default function PostReactionButtons({
-  postId,
+  postSlug,
   initialLikeCount,
   initialDislikeCount,
   initialUserReaction,
@@ -22,40 +22,40 @@ export default function PostReactionButtons({
   const [isPending, startTransition] = useTransition();
   const [likeCount, setLikeCount] = useState(initialLikeCount);
   const [dislikeCount, setDislikeCount] = useState(initialDislikeCount);
-  const [userReaction, setUserReaction] = useState<"like" | "dislike" | null>(
-    initialUserReaction
+  const [userReaction, setUserReaction] = useState<'like' | 'dislike' | null>(
+    initialUserReaction,
   );
 
-  const handleReaction = (type: "like" | "dislike") => {
+  const handleReaction = (type: 'like' | 'dislike') => {
     if (disabled || isPending) return;
     const prevReaction = userReaction;
     let newLikeCount = likeCount;
     let newDislikeCount = dislikeCount;
-    if (type === "like") {
-      if (userReaction === "like") {
+    if (type === 'like') {
+      if (userReaction === 'like') {
         newLikeCount -= 1;
         setUserReaction(null);
       } else {
         newLikeCount += 1;
-        if (userReaction === "dislike") newDislikeCount -= 1;
-        setUserReaction("like");
+        if (userReaction === 'dislike') newDislikeCount -= 1;
+        setUserReaction('like');
       }
     } else {
-      if (userReaction === "dislike") {
+      if (userReaction === 'dislike') {
         newDislikeCount -= 1;
         setUserReaction(null);
       } else {
         newDislikeCount += 1;
-        if (userReaction === "like") newLikeCount -= 1;
-        setUserReaction("dislike");
+        if (userReaction === 'like') newLikeCount -= 1;
+        setUserReaction('dislike');
       }
     }
     setLikeCount(newLikeCount);
     setDislikeCount(newDislikeCount);
     startTransition(async () => {
-      const res = await fetch(`/api/posts/${postId}/reactions`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      const res = await fetch(`/api/posts/${postSlug}/reactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ type }),
       });
       if (res.ok) {
@@ -75,35 +75,35 @@ export default function PostReactionButtons({
   return (
     <div className="flex items-center gap-2">
       <Button
-        variant={userReaction === "like" ? "default" : "ghost"}
+        variant={userReaction === 'like' ? 'default' : 'ghost'}
         size="icon"
-        aria-label={userReaction === "like" ? "Unlike post" : "Like post"}
-        onClick={() => handleReaction("like")}
+        aria-label={userReaction === 'like' ? 'Unlike post' : 'Like post'}
+        onClick={() => handleReaction('like')}
         disabled={disabled || isPending}
         className="rounded-full"
       >
         <ThumbsUp
           className={
-            userReaction === "like" ? "text-accent" : "text-muted-foreground"
+            userReaction === 'like' ? 'text-accent' : 'text-muted-foreground'
           }
         />
       </Button>
       <span className="text-sm tabular-nums w-6 text-center">{likeCount}</span>
       <Button
-        variant={userReaction === "dislike" ? "destructive" : "ghost"}
+        variant={userReaction === 'dislike' ? 'destructive' : 'ghost'}
         size="icon"
         aria-label={
-          userReaction === "dislike" ? "Remove dislike" : "Dislike post"
+          userReaction === 'dislike' ? 'Remove dislike' : 'Dislike post'
         }
-        onClick={() => handleReaction("dislike")}
+        onClick={() => handleReaction('dislike')}
         disabled={disabled || isPending}
         className="rounded-full"
       >
         <ThumbsDown
           className={
-            userReaction === "dislike"
-              ? "text-destructive"
-              : "text-muted-foreground"
+            userReaction === 'dislike'
+              ? 'text-destructive'
+              : 'text-muted-foreground'
           }
         />
       </Button>
@@ -113,4 +113,3 @@ export default function PostReactionButtons({
     </div>
   );
 }
-

--- a/src/components/app/posts/organisms/CommentsSection.tsx
+++ b/src/components/app/posts/organisms/CommentsSection.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { ThumbsUp, ThumbsDown, MessageCircle, Loader2 } from "lucide-react";
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { ThumbsUp, ThumbsDown, MessageCircle, Loader2 } from 'lucide-react';
 
 interface Comment {
   id: string;
@@ -18,39 +18,39 @@ interface Comment {
 }
 
 interface CommentsSectionProps {
-  postId: string;
+  postSlug: string;
   currentUserId: string | null;
 }
 
 export default function CommentsSection({
-  postId,
+  postSlug,
   currentUserId,
 }: CommentsSectionProps) {
   const [comments, setComments] = useState<Comment[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [newComment, setNewComment] = useState("");
+  const [newComment, setNewComment] = useState('');
   const [replyTo, setReplyTo] = useState<string | null>(null);
   const [posting, setPosting] = useState(false);
 
   useEffect(() => {
-    fetch(`/api/posts/${postId}/comments`)
+    fetch(`/api/posts/${postSlug}/comments`)
       .then((res) => res.json())
       .then((data) => setComments(data.comments || []))
       .finally(() => setIsLoading(false));
-  }, [postId]);
+  }, [postSlug]);
 
   const handlePost = async (parent_id?: string) => {
     if (!newComment.trim()) return;
     setPosting(true);
-    const res = await fetch(`/api/posts/${postId}/comments`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    const res = await fetch(`/api/posts/${postSlug}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content: newComment, parent_id }),
     });
     if (res.ok) {
       const { comment } = await res.json();
       setComments((prev) => [...prev, comment]);
-      setNewComment("");
+      setNewComment('');
       setReplyTo(null);
     }
     setPosting(false);
@@ -69,40 +69,40 @@ export default function CommentsSection({
   function CommentItem({ comment }: { comment: Comment }) {
     const [likeCount, setLikeCount] = useState(comment.like_count || 0);
     const [dislikeCount, setDislikeCount] = useState(
-      comment.dislike_count || 0
+      comment.dislike_count || 0,
     );
-    const [userReaction, setUserReaction] = useState<"like" | "dislike" | null>(
-      null
+    const [userReaction, setUserReaction] = useState<'like' | 'dislike' | null>(
+      null,
     );
-    const handleReact = (type: "like" | "dislike") => {
+    const handleReact = (type: 'like' | 'dislike') => {
       if (!currentUserId) return;
       const prevReaction = userReaction;
       let newLike = likeCount,
         newDislike = dislikeCount;
-      if (type === "like") {
-        if (userReaction === "like") {
+      if (type === 'like') {
+        if (userReaction === 'like') {
           newLike -= 1;
           setUserReaction(null);
         } else {
           newLike += 1;
-          if (userReaction === "dislike") newDislike -= 1;
-          setUserReaction("like");
+          if (userReaction === 'dislike') newDislike -= 1;
+          setUserReaction('like');
         }
       } else {
-        if (userReaction === "dislike") {
+        if (userReaction === 'dislike') {
           newDislike -= 1;
           setUserReaction(null);
         } else {
           newDislike += 1;
-          if (userReaction === "like") newLike -= 1;
-          setUserReaction("dislike");
+          if (userReaction === 'like') newLike -= 1;
+          setUserReaction('dislike');
         }
       }
       setLikeCount(newLike);
       setDislikeCount(newDislike);
       fetch(`/api/comments/${comment.id}/reactions`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ type }),
       })
         .then((res) => res.json())
@@ -121,7 +121,7 @@ export default function CommentsSection({
       <div className="mb-4">
         <div className="flex items-center gap-2">
           <span className="font-medium text-sm">
-            {comment.user_full_name || "User"}
+            {comment.user_full_name || 'User'}
           </span>
           <span className="text-xs text-muted-foreground">
             {new Date(comment.created_at).toLocaleString()}
@@ -130,20 +130,20 @@ export default function CommentsSection({
         <div className="ml-2 text-sm">{comment.content}</div>
         <div className="flex items-center gap-2 ml-2 mt-1">
           <Button
-            variant={userReaction === "like" ? "default" : "ghost"}
+            variant={userReaction === 'like' ? 'default' : 'ghost'}
             size="icon"
             aria-label={
-              userReaction === "like" ? "Unlike comment" : "Like comment"
+              userReaction === 'like' ? 'Unlike comment' : 'Like comment'
             }
-            onClick={() => handleReact("like")}
+            onClick={() => handleReact('like')}
             disabled={!currentUserId}
             className="rounded-full"
           >
             <ThumbsUp
               className={
-                userReaction === "like"
-                  ? "text-accent"
-                  : "text-muted-foreground"
+                userReaction === 'like'
+                  ? 'text-accent'
+                  : 'text-muted-foreground'
               }
             />
           </Button>
@@ -151,20 +151,20 @@ export default function CommentsSection({
             {likeCount}
           </span>
           <Button
-            variant={userReaction === "dislike" ? "destructive" : "ghost"}
+            variant={userReaction === 'dislike' ? 'destructive' : 'ghost'}
             size="icon"
             aria-label={
-              userReaction === "dislike" ? "Remove dislike" : "Dislike comment"
+              userReaction === 'dislike' ? 'Remove dislike' : 'Dislike comment'
             }
-            onClick={() => handleReact("dislike")}
+            onClick={() => handleReact('dislike')}
             disabled={!currentUserId}
             className="rounded-full"
           >
             <ThumbsDown
               className={
-                userReaction === "dislike"
-                  ? "text-destructive"
-                  : "text-muted-foreground"
+                userReaction === 'dislike'
+                  ? 'text-destructive'
+                  : 'text-muted-foreground'
               }
             />
           </Button>
@@ -206,9 +206,7 @@ export default function CommentsSection({
                 onClick={() => handlePost(comment.id)}
                 disabled={posting}
               >
-                {posting && (
-                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                )}
+                {posting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
                 {posting ? 'Posting…' : 'Post'}
               </Button>
               <Button
@@ -253,9 +251,7 @@ export default function CommentsSection({
             rows={3}
           />
           <Button onClick={() => handlePost()} disabled={posting}>
-            {posting && (
-              <Loader2 className="h-4 w-4 animate-spin mr-2" />
-            )}
+            {posting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
             {posting ? 'Posting…' : 'Post Comment'}
           </Button>
         </div>

--- a/src/components/app/profile/AudioSlider.tsx
+++ b/src/components/app/profile/AudioSlider.tsx
@@ -1,10 +1,11 @@
-"use client";
-import React from "react";
-import Link from "next/link";
-import type { Database } from "@/lib/database.types";
+'use client';
+import React from 'react';
+import Link from 'next/link';
+import type { Database } from '@/lib/database.types';
 
 // Basic post type with optional audioUrl
-export type AudioPost = Database["public"]["Tables"]["posts"]["Row"] & {
+export type AudioPost = Database['public']['Tables']['posts']['Row'] & {
+  slug?: string | null;
   audio_url?: string | null;
 };
 
@@ -20,7 +21,13 @@ export default function AudioSlider({ posts }: AudioSliderProps) {
         {posts.map((post) => (
           <Link
             key={post.id}
-            href={post.slug ? `/posts/${post.slug}` : (post.collective_slug ? `/collectives/${post.collective_slug}/${post.id}` : `/posts/${post.id}`)}
+            href={
+              post.slug
+                ? `/posts/${post.slug}`
+                : post.collective_slug
+                  ? `/collectives/${post.collective_slug}/${post.id}`
+                  : `/posts/${post.id}`
+            }
             className="shrink-0 w-48 bg-card rounded-xl shadow p-3 hover:ring-2 hover:ring-primary transition"
           >
             <div className="h-24 bg-muted rounded mb-2" />


### PR DESCRIPTION
## Summary
- use post slugs when sending requests from the post page
- adjust BookmarkButton, PostReactionButtons and CommentsSection to accept `postSlug`
- update dashboard and editor links to use slugs
- correct API endpoints to resolve slugs to post IDs before database actions
- fix edit post form props and usage
- include slug fields in various post-related types

## Testing
- `pnpm lint`
- `pnpm test`
