### PR TITLE
Remove heavy editor CSS

### DIFF
--- a/src/components/LexicalPlaygroundEditor.tsx
+++ b/src/components/LexicalPlaygroundEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import '@/components/lexical-playground/index.css';
+import '@/styles/editor.css';
 
 // Lazy-load the heavy playground so it doesn't bloat the first bundle.
 const PlaygroundApp = dynamic(

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import '@/components/lexical-playground/index.css';
+import '@/styles/editor.css';
 
 interface PostEditorProps {
   initialContent?: string;

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -1,0 +1,22 @@
+/* Minimal styles for PostEditor layout */
+.editor-shell {
+  margin: 1rem auto;
+  max-width: 1100px;
+  position: relative;
+}
+
+.editor-container {
+  background: var(--background);
+  border-radius: var(--radius);
+  position: relative;
+}
+
+.editor-scroller {
+  min-height: 150px;
+  display: flex;
+}
+
+.editor {
+  flex: auto;
+  max-width: 100%;
+}


### PR DESCRIPTION
## Summary
- scope Lexical editor styles in a new CSS file
- stop importing the large playground stylesheet

## Testing
- `pnpm lint` *(fails: Next.js telemetry and lint errors)*
- `pnpm typecheck` *(fails to compile)*
- `pnpm test` *(fails to run tests)*