### PR TITLE
Scope lexical playground styles

### DIFF
--- a/src/components/editor/LexicalPlaygroundEditorInternal.tsx
+++ b/src/components/editor/LexicalPlaygroundEditorInternal.tsx
@@ -134,16 +134,18 @@ export default function LexicalPlaygroundEditorInternal({
   };
 
   return (
-    <LexicalComposer initialConfig={initialConfig}>
-      <SharedHistoryContext>
-        <ToolbarContext>
-          <EditorContent
-            placeholder={placeholder}
-            initialContent={initialContent}
-            onChange={onChange}
-          />
-        </ToolbarContext>
-      </SharedHistoryContext>
-    </LexicalComposer>
+    <div className="lexical-playground">
+      <LexicalComposer initialConfig={initialConfig}>
+        <SharedHistoryContext>
+          <ToolbarContext>
+            <EditorContent
+              placeholder={placeholder}
+              initialContent={initialContent}
+              onChange={onChange}
+            />
+          </ToolbarContext>
+        </SharedHistoryContext>
+      </LexicalComposer>
+    </div>
   );
 }

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -15,12 +15,13 @@ const LexicalPlaygroundEditor = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="editor-shell" style={{ minHeight: 250 }}>
-        <div
-          className="toolbar"
-          style={{
-            height: 48,
-            minHeight: 48,
+      <div className="lexical-playground">
+        <div className="editor-shell" style={{ minHeight: 250 }}>
+          <div
+            className="toolbar"
+            style={{
+              height: 48,
+              minHeight: 48,
             display: 'flex',
             alignItems: 'center',
             padding: '8px 12px',
@@ -29,10 +30,11 @@ const LexicalPlaygroundEditor = dynamic(
           }}
         >
           {/* Toolbar placeholder: keep height and flex structure */}
-        </div>
-        <div className="editor-container">
-          <div className="editor-scroller" style={{ minHeight: 150 }}>
-            <div className="editor" />
+          </div>
+          <div className="editor-container">
+            <div className="editor-scroller" style={{ minHeight: 150 }}>
+              <div className="editor" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/lexical-playground/index.css
+++ b/src/components/lexical-playground/index.css
@@ -8,17 +8,9 @@
 
 @import 'https://fonts.googleapis.com/css?family=Reenie+Beanie';
 
-body {
-  margin: 0;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  background: #eee;
-  padding: 0 20px;
-}
 
-header {
+
+.lexical-playground header {
   max-width: 580px;
   margin: auto;
   position: relative;
@@ -26,19 +18,19 @@ header {
   justify-content: center;
 }
 
-header a {
+.lexical-playground header a {
   max-width: 220px;
   margin: 20px 0 0 0;
   display: block;
 }
 
-header img {
+.lexical-playground header img {
   display: block;
   height: 100%;
   width: 100%;
 }
 
-header h1 {
+.lexical-playground header h1 {
   text-align: left;
   color: #333;
   display: inline-block;
@@ -96,7 +88,7 @@ header h1 {
   width: 100%;
 }
 
-pre {
+.lexical-playground pre {
   line-height: 1.1;
   background: #222;
   color: #fff;
@@ -120,12 +112,12 @@ pre {
   border-bottom-right-radius: 10px;
 }
 
-pre::-webkit-scrollbar {
+.lexical-playground pre::-webkit-scrollbar {
   background: transparent;
   width: 10px;
 }
 
-pre::-webkit-scrollbar-thumb {
+.lexical-playground pre::-webkit-scrollbar-thumb {
   background: #999;
 }
 


### PR DESCRIPTION
## Summary
- avoid global body styles from lexical editor
- prefix header and pre styles with `.lexical-playground`
- wrap editor components in `.lexical-playground` container

## Testing
- `pnpm test` *(fails: Cannot find module '../Navbar' from NavbarEditorRoute.test.tsx)*