### PR TITLE
Remove global header styles from lexical playground

### DIFF
--- a/src/components/lexical-playground/index.css
+++ b/src/components/lexical-playground/index.css
@@ -8,35 +8,6 @@
 
 @import 'https://fonts.googleapis.com/css?family=Reenie+Beanie';
 
-
-
-.lexical-playground header {
-  max-width: 580px;
-  margin: auto;
-  position: relative;
-  display: flex;
-  justify-content: center;
-}
-
-.lexical-playground header a {
-  max-width: 220px;
-  margin: 20px 0 0 0;
-  display: block;
-}
-
-.lexical-playground header img {
-  display: block;
-  height: 100%;
-  width: 100%;
-}
-
-.lexical-playground header h1 {
-  text-align: left;
-  color: #333;
-  display: inline-block;
-  margin: 20px 0 0 0;
-}
-
 .editor-shell {
   margin: 20px auto;
   border-radius: 2px;


### PR DESCRIPTION
## Summary
- drop `header` styling from `lexical-playground/index.css` so it won't override main layout

## Testing
- `pnpm lint` *(fails: sort-keys-fix rule missing and unused vars)*
- `pnpm typecheck` *(fails to compile)*
- `pnpm test` *(fails: NavbarEditorRoute and SlashMenuUtils tests fail)*