### PR TITLE
Fix editor theming

### DIFF
--- a/src/components/lexical-playground/index.css
+++ b/src/components/lexical-playground/index.css
@@ -12,14 +12,14 @@
   margin: 20px auto;
   border-radius: 2px;
   max-width: 1100px;
-  color: #000;
+  color: hsl(var(--foreground));
   position: relative;
   line-height: 1.7;
   font-weight: 400;
 }
 
 .editor-shell .editor-container {
-  background: #fff;
+  background: hsl(var(--card));
   position: relative;
   display: block;
   border-bottom-left-radius: 10px;
@@ -61,8 +61,8 @@
 
 .lexical-playground pre {
   line-height: 1.1;
-  background: #222;
-  color: #fff;
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
   margin: 0;
   padding: 10px;
   font-size: 12px;
@@ -72,8 +72,8 @@
 
 .tree-view-output {
   display: block;
-  background: #222;
-  color: #fff;
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
   padding: 0;
   font-size: 12px;
   margin: 1px auto 10px auto;
@@ -223,7 +223,7 @@
 }
 
 .typeahead-popover {
-  background: #fff;
+  background: hsl(var(--card));
   box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.3);
   border-radius: 8px;
   position: relative;
@@ -271,7 +271,7 @@
   align-content: center;
   flex-direction: row;
   flex-shrink: 0;
-  background-color: #fff;
+  background-color: hsl(var(--card));
   border-radius: 8px;
   border: 0;
 }
@@ -724,7 +724,7 @@ i.page-break,
     inset 0 0 0 1px rgba(255, 255, 255, 0.5);
   border-radius: 8px;
   min-height: 40px;
-  background-color: #fff;
+  background-color: hsl(var(--card));
 }
 
 .dropdown .item {
@@ -739,7 +739,7 @@ i.page-break,
   flex-direction: row;
   flex-shrink: 0;
   justify-content: space-between;
-  background-color: #fff;
+  background-color: hsl(var(--card));
   border-radius: 8px;
   border: 0;
   max-width: 264px;
@@ -1001,10 +1001,10 @@ i.page-break,
   right: 0;
   padding: 0;
   margin: 0;
-  border-top: 1px solid #fff;
-  background-color: rgba(255, 255, 255, 0.9);
+  border-top: 1px solid hsl(var(--border));
+  background-color: hsl(var(--background) / 0.9);
   min-width: 100px;
-  color: #000;
+  color: hsl(var(--foreground));
   overflow: hidden;
 }
 
@@ -1021,7 +1021,7 @@ i.page-break,
   border-radius: 5px;
   background-color: rgba(0, 0, 0, 0.5);
   min-width: 100px;
-  color: #fff;
+  color: hsl(var(--foreground));
   cursor: pointer;
   user-select: none;
 }
@@ -1057,7 +1057,7 @@ i.page-break,
   height: 7px;
   position: absolute;
   background-color: rgb(60, 132, 244);
-  border: 1px solid #fff;
+  border: 1px solid hsl(var(--background));
 }
 
 .editor-shell .editor-image .image-resizer.image-resizer-n {
@@ -1164,7 +1164,7 @@ i.page-break,
   border-radius: 5px;
   background-color: rgba(0, 0, 0, 0.5);
   min-width: 60px;
-  color: #fff;
+  color: hsl(var(--foreground));
   cursor: pointer;
   user-select: none;
 }
@@ -1175,15 +1175,15 @@ i.page-break,
 
 .editor-shell .inline-editor-image .image-caption-container {
   display: block;
-  background-color: #f4f4f4;
+  background-color: hsl(var(--muted));
   min-width: 100%;
-  color: #000;
+  color: hsl(var(--foreground));
   overflow: hidden;
 }
 
 .emoji {
   color: transparent;
-  caret-color: rgb(5, 5, 5);
+  caret-color: hsl(var(--foreground));
   background-size: 16px 16px;
   background-position: center;
   background-repeat: no-repeat;
@@ -1347,8 +1347,8 @@ i.chevron-down {
 }
 
 .action-button:hover {
-  background-color: #ddd;
-  color: #000;
+  background-color: hsl(var(--muted));
+  color: hsl(var(--foreground));
 }
 
 .action-button-mic.active {
@@ -1392,7 +1392,7 @@ button.action-button:disabled {
   border: 0;
   background: none;
   flex: 1;
-  color: #fff;
+  color: hsl(var(--foreground));
   font-size: 12px;
 }
 
@@ -1408,7 +1408,7 @@ button.action-button:disabled {
   right: 15px;
   position: absolute;
   background: none;
-  color: #fff;
+  color: hsl(var(--foreground));
 }
 
 .debug-timetravel-button:hover {
@@ -1423,7 +1423,7 @@ button.action-button:disabled {
   right: 85px;
   position: absolute;
   background: none;
-  color: #fff;
+  color: hsl(var(--foreground));
 }
 
 .debug-treetype-button:hover {
@@ -1455,7 +1455,7 @@ button.action-button:disabled {
 .toolbar {
   display: flex;
   margin-bottom: 1px;
-  background: #fff;
+  background: hsl(var(--card));
   padding: 4px;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;

--- a/src/components/lexical-playground/themes/PlaygroundEditorTheme.css
+++ b/src/components/lexical-playground/themes/PlaygroundEditorTheme.css
@@ -21,21 +21,21 @@
   margin-left: 20px;
   margin-bottom: 10px;
   font-size: 15px;
-  color: rgb(101, 103, 107);
-  border-left-color: rgb(206, 208, 212);
+  color: hsl(var(--muted-foreground));
+  border-left-color: hsl(var(--border));
   border-left-width: 4px;
   border-left-style: solid;
   padding-left: 16px;
 }
 .PlaygroundEditorTheme__h1 {
   font-size: 24px;
-  color: rgb(5, 5, 5);
+  color: hsl(var(--foreground));
   font-weight: 400;
   margin: 0;
 }
 .PlaygroundEditorTheme__h2 {
   font-size: 15px;
-  color: rgb(101, 103, 107);
+  color: hsl(var(--muted-foreground));
   font-weight: 700;
   margin: 0;
   text-transform: uppercase;
@@ -123,7 +123,7 @@
   vertical-align: super;
 }
 .PlaygroundEditorTheme__textCode {
-  background-color: rgb(240, 242, 245);
+  background-color: hsl(var(--muted));
   padding: 1px 0.25rem;
   font-family: Menlo, Consolas, Monaco, monospace;
   font-size: 94%;
@@ -142,7 +142,7 @@
   border-bottom: 1px solid rgba(88, 144, 255, 0.3);
 }
 .PlaygroundEditorTheme__link {
-  color: rgb(33, 111, 219);
+  color: hsl(var(--accent));
   text-decoration: none;
 }
 .PlaygroundEditorTheme__link:hover {
@@ -169,7 +169,7 @@
   }
 }
 .PlaygroundEditorTheme__code {
-  background-color: rgb(240, 242, 245);
+  background-color: hsl(var(--muted));
   font-family: Menlo, Consolas, Monaco, monospace;
   display: block;
   padding: 8px 8px 8px 52px;
@@ -185,12 +185,12 @@
 .PlaygroundEditorTheme__code:before {
   content: attr(data-gutter);
   position: absolute;
-  background-color: #eee;
+  background-color: hsl(var(--muted));
   left: 0;
   top: 0;
-  border-right: 1px solid #ccc;
+  border-right: 1px solid hsl(var(--border));
   padding: 8px;
-  color: #777;
+  color: hsl(var(--muted-foreground));
   white-space: pre-wrap;
   text-align: right;
   min-width: 25px;
@@ -235,7 +235,7 @@
 }
 .PlaygroundEditorTheme__tableFrozenRow tr:nth-of-type(1) > th {
   overflow: clip;
-  background-color: #f2f3f5;
+  background-color: hsl(var(--muted));
   position: sticky;
   z-index: 2;
   top: 44px;
@@ -247,16 +247,16 @@
   left: 0;
   bottom: 0;
   width: 100%;
-  border-bottom: 1px solid #bbb;
+  border-bottom: 1px solid hsl(var(--border));
 }
 .PlaygroundEditorTheme__tableFrozenColumn tr > td:first-child {
-  background-color: #ffffff;
+  background-color: hsl(var(--card));
   position: sticky;
   z-index: 2;
   left: 0;
 }
 .PlaygroundEditorTheme__tableFrozenColumn tr > th:first-child {
-  background-color: #f2f3f5;
+  background-color: hsl(var(--muted));
   position: sticky;
   z-index: 2;
   left: 0;
@@ -268,19 +268,19 @@
   top: 0;
   right: 0;
   height: 100%;
-  border-right: 1px solid #bbb;
+  border-right: 1px solid hsl(var(--border));
 }
 .PlaygroundEditorTheme__tableRowStriping tr:nth-child(even) {
-  background-color: #f2f5fb;
+  background-color: hsl(var(--muted));
 }
 .PlaygroundEditorTheme__tableSelection *::selection {
   background-color: transparent;
 }
 .PlaygroundEditorTheme__tableSelected {
-  outline: 2px solid rgb(60, 132, 244);
+  outline: 2px solid hsl(var(--accent));
 }
 .PlaygroundEditorTheme__tableCell {
-  border: 1px solid #bbb;
+  border: 1px solid hsl(var(--border));
   width: 75px;
   vertical-align: top;
   text-align: start;
@@ -306,7 +306,7 @@
   top: 0;
 }
 .PlaygroundEditorTheme__tableCellHeader {
-  background-color: #f2f3f5;
+  background-color: hsl(var(--muted));
   text-align: start;
 }
 .PlaygroundEditorTheme__tableCellSelected {
@@ -325,7 +325,7 @@
 }
 .PlaygroundEditorTheme__tableAddColumns {
   position: absolute;
-  background-color: #eee;
+  background-color: hsl(var(--muted));
   height: 100%;
   animation: table-controls 0.2s ease;
   border: 0;
@@ -352,7 +352,7 @@
 .PlaygroundEditorTheme__tableAddRows {
   position: absolute;
   width: calc(100% - 25px);
-  background-color: #eee;
+  background-color: hsl(var(--muted));
   animation: table-controls 0.2s ease;
   border: 0;
   cursor: pointer;
@@ -383,7 +383,7 @@
   display: block;
   position: absolute;
   width: 1px;
-  background-color: rgb(60, 132, 244);
+  background-color: hsl(var(--accent));
   height: 100%;
   top: 0;
 }
@@ -397,7 +397,7 @@
   height: 20px;
 }
 .PlaygroundEditorTheme__tableCellActionButton {
-  background-color: #eee;
+  background-color: hsl(var(--muted));
   display: block;
   border: 0;
   border-radius: 20px;
@@ -407,7 +407,7 @@
   cursor: pointer;
 }
 .PlaygroundEditorTheme__tableCellActionButton:hover {
-  background-color: #ddd;
+  background-color: hsl(var(--muted));
 }
 .PlaygroundEditorTheme__characterLimit {
   display: inline;
@@ -496,9 +496,9 @@
   border-radius: 2px;
 }
 .PlaygroundEditorTheme__listItemChecked:before {
-  border: 1px solid rgb(61, 135, 245);
+  border: 1px solid hsl(var(--accent));
   border-radius: 2px;
-  background-color: #3d87f5;
+  background-color: hsl(var(--accent));
   background-repeat: no-repeat;
 }
 .PlaygroundEditorTheme__listItemChecked:after {
@@ -568,7 +568,7 @@
   user-select: none;
 }
 .PlaygroundEditorTheme__embedBlockFocus {
-  outline: 2px solid rgb(60, 132, 244);
+  outline: 2px solid hsl(var(--accent));
 }
 .PlaygroundEditorTheme__layoutContainer {
   display: grid;
@@ -576,13 +576,13 @@
   margin: 10px 0;
 }
 .PlaygroundEditorTheme__layoutItem {
-  border: 1px dashed #ddd;
+  border: 1px dashed hsl(var(--border));
   padding: 8px 16px;
   min-width: 0;
   max-width: 100%;
 }
 .PlaygroundEditorTheme__autocomplete {
-  color: #ccc;
+  color: hsl(var(--muted-foreground));
 }
 .PlaygroundEditorTheme__hr {
   padding: 2px 2px;
@@ -594,11 +594,11 @@
   content: '';
   display: block;
   height: 2px;
-  background-color: #ccc;
+  background-color: hsl(var(--border));
   line-height: 2px;
 }
 .PlaygroundEditorTheme__hr.PlaygroundEditorTheme__hrSelected {
-  outline: 2px solid rgb(60, 132, 244);
+  outline: 2px solid hsl(var(--accent));
   user-select: none;
 }
 


### PR DESCRIPTION
## Summary
- integrate Lexical Playground CSS with Tailwind theme colors
- use design tokens in editor theme styles

## Testing
- `pnpm test` *(fails: Test suite failed to run)*