### PR TITLE
Improve editor responsive design

### DIFF
--- a/src/components/editor/plugins/PlusButtonPlugin.tsx
+++ b/src/components/editor/plugins/PlusButtonPlugin.tsx
@@ -53,9 +53,9 @@ export default function PlusButtonPlugin() {
         handleClick();
       }}
       style={{ position: 'absolute', top: pos.top, left: pos.left }}
-      className="p-1 opacity-80 hover:opacity-100 text-muted-foreground"
+      className="p-2 sm:p-1 opacity-80 hover:opacity-100 text-muted-foreground"
     >
-      <img src="/plus-slash-minus.svg" alt="add" className="w-4 h-4" />
+      <img src="/plus-slash-minus.svg" alt="add" className="w-5 h-5 sm:w-4 sm:h-4" />
     </button>,
     root.parentElement || root,
   );

--- a/src/components/editor/styles/EditorLayout.module.css
+++ b/src/components/editor/styles/EditorLayout.module.css
@@ -8,6 +8,14 @@
   font-weight:400;
 }
 
+@media (max-width: 640px){
+  :global(.editor-shell){
+    max-width:100%;
+    padding-left:16px;
+    padding-right:16px;
+  }
+}
+
 :global(.editor-shell .editor-container){
   background:transparent;
   position:relative;
@@ -34,4 +42,15 @@
   position:relative;
   resize:vertical;
   z-index:-1;
+}
+
+:global(.editor img){
+  max-width:100%;
+  height:auto;
+}
+
+:global(.editor table){
+  display:block;
+  width:100%;
+  overflow-x:auto;
 }

--- a/src/components/editor/styles/Menus.module.css
+++ b/src/components/editor/styles/Menus.module.css
@@ -48,3 +48,12 @@
 :global(.mentions-menu){width:250px;}
 :global(.auto-embed-menu){width:150px;}
 :global(.emoji-menu){width:200px;}
+
+@media (max-width: 640px){
+  :global(.typeahead-popover){
+    width:90vw;
+  }
+  :global(.typeahead-popover ul){
+    max-height:40vh;
+  }
+}

--- a/src/components/editor/styles/Toolbar.module.css
+++ b/src/components/editor/styles/Toolbar.module.css
@@ -6,7 +6,9 @@
   border-top-left-radius:10px;
   border-top-right-radius:10px;
   vertical-align:middle;
-  overflow:auto;
+  flex-wrap:nowrap;
+  overflow-x:auto;
+  -webkit-overflow-scrolling:touch;
   height:36px;
   position:sticky;
   top:0;
@@ -30,6 +32,15 @@
   flex-shrink:0;
   align-items:center;
   justify-content:space-between;
+}
+
+@media (max-width: 640px){
+  :global(button.toolbar-item){
+    padding:10px;
+  }
+  :global(.toolbar){
+    padding:4px 8px;
+  }
 }
 
 :global(button.toolbar-item:disabled){


### PR DESCRIPTION
## Summary
- tweak `EditorLayout` for mobile padding and fluid width
- make toolbar scrollable on small screens
- adapt slash menu popup size on mobile
- ensure images and tables scale to viewport
- enlarge slash `+` button hit area on touch devices

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: Navbar and FollowButton tests)*