### PR TITLE
Add slash menu automated test

### DIFF
--- a/tests/e2e/editor-slash-menu.spec.ts
+++ b/tests/e2e/editor-slash-menu.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Editor slash menu', () => {
+  test('opens component picker on /', async ({ page }) => {
+    await page.goto('/test-editor');
+    const editor = page.locator('.editor [contenteditable="true"]');
+    await editor.click();
+    await page.keyboard.type('/');
+    const menu = page.locator('.component-picker-menu');
+    await expect(menu).toBeVisible();
+    await expect(menu).toContainText('Paragraph');
+    await expect(menu).toContainText('Heading 1');
+  });
+});


### PR DESCRIPTION
## Summary
- automate slash command test using Playwright

## Testing
- `pnpm test`
- `npx playwright test tests/e2e/editor-slash-menu.spec.ts` *(fails: browsers not installed)*