### PR TITLE
Move edit post title field to main canvas

### DIFF
--- a/src/app/(editor)/posts/[slug]/edit/EditPostForm.tsx
+++ b/src/app/(editor)/posts/[slug]/edit/EditPostForm.tsx
@@ -19,6 +19,7 @@ import PostFormFields from '@/components/app/editor/form-fields/PostFormFields';
 import PostEditor from '@/components/editor/PostEditor';
 import SEOSettingsDrawer from '@/components/editor/SEOSettingsDrawer';
 import { EMPTY_LEXICAL_STATE } from '@/lib/editorConstants';
+import { Input } from '@/components/ui/input';
 
 type EditPostFormValues = PostFormValues;
 
@@ -230,6 +231,7 @@ export default function EditPostForm({
         currentStatus={currentStatus}
         isSubmitting={isProcessing || isSubmitting || isDeleting}
         titlePlaceholder="Edit Post Title"
+        showTitle={false}
       />
       <Button
         type="button"
@@ -296,13 +298,24 @@ export default function EditPostForm({
   );
 
   const canvas = (
-    <PostEditor
-      initialContent={getValues('content')}
-      placeholder="Continue writing..."
-      onChange={(json) =>
-        setValue('content', json, { shouldValidate: true, shouldDirty: true })
-      }
-    />
+    <div className="space-y-6">
+      <Input
+        id="title"
+        {...register('title')}
+        placeholder="Edit post title..."
+        className="w-full text-4xl font-bold border-none p-0 focus:ring-0 focus:outline-none placeholder:text-muted-foreground"
+      />
+      {errors.title && (
+        <p className="text-destructive text-sm">{errors.title.message as string}</p>
+      )}
+      <PostEditor
+        initialContent={getValues('content')}
+        placeholder="Continue writing..."
+        onChange={(json) =>
+          setValue('content', json, { shouldValidate: true, shouldDirty: true })
+        }
+      />
+    </div>
   );
 
   return (

--- a/src/components/app/editor/form-fields/PostFormFields.tsx
+++ b/src/components/app/editor/form-fields/PostFormFields.tsx
@@ -25,6 +25,10 @@ interface PostFormFieldsProps<TFormValues extends PostFormFieldsValues> {
   currentStatus: "draft" | "published" | "scheduled" | undefined;
   isSubmitting: boolean;
   titlePlaceholder?: string;
+  /**
+   * Whether to render the title field. Defaults to true.
+   */
+  showTitle?: boolean;
 }
 
 export default function PostFormFields<
@@ -35,6 +39,7 @@ export default function PostFormFields<
   currentStatus,
   isSubmitting,
   titlePlaceholder = "Post Title",
+  showTitle = true,
 }: PostFormFieldsProps<TFormValues>) {
   // Helper to safely access error messages
   const getErrorMessage = (
@@ -45,26 +50,28 @@ export default function PostFormFields<
 
   return (
     <>
-      <div>
-        <Label
-          htmlFor="title"
-          className="mb-1 block text-sm font-medium text-foreground"
-        >
-          Post Title
-        </Label>
-        <Input
-          id="title"
-          {...register("title" as Path<TFormValues>)}
-          placeholder={titlePlaceholder}
-          disabled={isSubmitting}
-          className={errors.title ? "border-destructive" : ""}
-        />
-        {errors.title && (
-          <p className="text-sm text-destructive mt-1">
-            {getErrorMessage(errors.title as FieldError)}
-          </p>
-        )}
-      </div>
+      {showTitle && (
+        <div>
+          <Label
+            htmlFor="title"
+            className="mb-1 block text-sm font-medium text-foreground"
+          >
+            Post Title
+          </Label>
+          <Input
+            id="title"
+            {...register("title" as Path<TFormValues>)}
+            placeholder={titlePlaceholder}
+            disabled={isSubmitting}
+            className={errors.title ? "border-destructive" : ""}
+          />
+          {errors.title && (
+            <p className="text-sm text-destructive mt-1">
+              {getErrorMessage(errors.title as FieldError)}
+            </p>
+          )}
+        </div>
+      )}
 
       <div className="space-y-2">
         <Label htmlFor="status" className="text-sm font-medium text-foreground">


### PR DESCRIPTION
## Summary
- allow hiding the title input in `PostFormFields`
- refactor `EditPostForm` to show the title above the editor like the new post form

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
