### PR TITLE
Polish editor typography and add subtitle field

### DIFF
--- a/src/app/(editor)/posts/[slug]/edit/EditPostForm.tsx
+++ b/src/app/(editor)/posts/[slug]/edit/EditPostForm.tsx
@@ -303,10 +303,19 @@ export default function EditPostForm({
         id="title"
         {...register('title')}
         placeholder="Edit post title..."
-        className="w-full text-4xl font-bold border-none p-0 focus:ring-0 focus:outline-none placeholder:text-muted-foreground"
+        className="w-full text-4xl font-bold font-serif border-none p-0 focus:ring-0 focus:outline-none placeholder:text-muted-foreground"
       />
       {errors.title && (
         <p className="text-destructive text-sm">{errors.title.message as string}</p>
+      )}
+      <Input
+        id="subtitle"
+        {...register('subtitle')}
+        placeholder="Add a subtitle..."
+        className="w-full text-2xl font-medium italic font-serif text-muted-foreground border-none p-0 focus:ring-0 focus:outline-none placeholder:text-muted-foreground"
+      />
+      {errors.subtitle && (
+        <p className="text-destructive text-sm">{errors.subtitle.message as string}</p>
       )}
       <PostEditor
         initialContent={getValues('content')}

--- a/src/app/(editor)/posts/new/NewPostForm.tsx
+++ b/src/app/(editor)/posts/new/NewPostForm.tsx
@@ -41,6 +41,7 @@ export default function NewPostForm({
     resolver: zodResolver(PostFormSchema),
     defaultValues: {
       title: '',
+      subtitle: '',
       content: EMPTY_LEXICAL_STATE,
       status: 'draft',
       published_at: '',
@@ -95,6 +96,7 @@ export default function NewPostForm({
     const data = getValues();
     const payload = {
       title: data.title,
+      subtitle: data.subtitle,
       content: data.content,
       is_public: false,
       published_at:
@@ -178,6 +180,7 @@ export default function NewPostForm({
       let result;
       const payload = {
         title: data.title,
+        subtitle: data.subtitle,
         content: data.content,
         is_public: is_public_for_action,
         published_at: published_at_for_action,
@@ -394,10 +397,19 @@ export default function NewPostForm({
             id="title"
             {...form.register('title')}
             placeholder="Enter post title..."
-            className="w-full text-4xl font-bold border-none p-0 focus:ring-0 focus:outline-none placeholder:text-muted-foreground"
+            className="w-full text-4xl font-bold font-serif border-none p-0 focus:ring-0 focus:outline-none placeholder:text-muted-foreground"
           />
           {errors.title && (
             <p className="text-destructive text-sm">{errors.title.message as string}</p>
+          )}
+          <Input
+            id="subtitle"
+            {...form.register('subtitle')}
+            placeholder="Add a subtitle..."
+            className="w-full text-2xl font-medium italic font-serif text-muted-foreground border-none p-0 focus:ring-0 focus:outline-none placeholder:text-muted-foreground"
+          />
+          {errors.subtitle && (
+            <p className="text-destructive text-sm">{errors.subtitle.message as string}</p>
           )}
           {editorComponent}
         </div>

--- a/src/components/lexical-playground/themes/PlaygroundEditorTheme.css
+++ b/src/components/lexical-playground/themes/PlaygroundEditorTheme.css
@@ -13,8 +13,11 @@
   text-align: right;
 }
 .PlaygroundEditorTheme__paragraph {
-  margin: 0;
+  margin: 0 0 1rem 0;
   position: relative;
+  font-family: var(--font-source-serif);
+  font-size: 1rem;
+  line-height: 1.7;
 }
 .PlaygroundEditorTheme__quote {
   margin: 0;
@@ -28,22 +31,25 @@
   padding-left: 16px;
 }
 .PlaygroundEditorTheme__h1 {
-  font-size: 24px;
+  font-family: var(--font-source-serif);
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 1.5rem 0 1rem 0;
   color: hsl(var(--foreground));
-  font-weight: 400;
-  margin: 0;
 }
 .PlaygroundEditorTheme__h2 {
-  font-size: 15px;
-  color: hsl(var(--muted-foreground));
-  font-weight: 700;
-  margin: 0;
-  text-transform: uppercase;
+  font-family: var(--font-source-serif);
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 1.25rem 0 0.75rem 0;
+  color: hsl(var(--foreground));
 }
 .PlaygroundEditorTheme__h3 {
-  font-size: 12px;
-  margin: 0;
-  text-transform: uppercase;
+  font-family: var(--font-source-serif);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem 0;
+  color: hsl(var(--foreground));
 }
 .PlaygroundEditorTheme__indent {
   --lexical-indent-base-value: 40px;


### PR DESCRIPTION
## Summary
- adjust Lexical theme to use Source Serif for headings and paragraphs
- use serif font for post title
- add optional subtitle input on new/edit post forms
- include subtitle in form payloads

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
