### PR TITLE
Integrate Supabase storage for post images

### DIFF
--- a/src/components/lexical-playground/plugins/ImagesPlugin/index.tsx
+++ b/src/components/lexical-playground/plugins/ImagesPlugin/index.tsx
@@ -46,6 +46,7 @@ import {
 import Button from '../../ui/Button';
 import { DialogActions, DialogButtonsList } from '../../ui/Dialog';
 import FileInput from '../../ui/FileInput';
+import { uploadPostImage } from '@/lib/uploadPostImage';
 import TextInput from '../../ui/TextInput';
 
 export type InsertImagePayload = Readonly<ImagePayload>;
@@ -99,20 +100,20 @@ export function InsertImageUploadedDialogBody({
 }) {
   const [src, setSrc] = useState('');
   const [altText, setAltText] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
 
-  const isDisabled = src === '';
+  const isDisabled = src === '' || isUploading;
 
-  const loadImage = (files: FileList | null) => {
-    const reader = new FileReader();
-    reader.onload = function () {
-      if (typeof reader.result === 'string') {
-        setSrc(reader.result);
-      }
-      return '';
-    };
-    if (files !== null) {
-      reader.readAsDataURL(files[0]);
+  const loadImage = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    setIsUploading(true);
+    const { url, error } = await uploadPostImage(files[0]);
+    if (url) {
+      setSrc(url);
+    } else {
+      console.error('Image upload failed:', error);
     }
+    setIsUploading(false);
   };
 
   return (

--- a/src/components/lexical-playground/plugins/InlineImagePlugin/index.tsx
+++ b/src/components/lexical-playground/plugins/InlineImagePlugin/index.tsx
@@ -46,6 +46,7 @@ import {
 import Button from '../../ui/Button';
 import { DialogActions } from '../../ui/Dialog';
 import FileInput from '../../ui/FileInput';
+import { uploadPostImage } from '@/lib/uploadPostImage';
 import Select from '../../ui/Select';
 import TextInput from '../../ui/TextInput';
 
@@ -68,7 +69,9 @@ export function InsertInlineImageDialog({
   const [showCaption, setShowCaption] = useState(false);
   const [position, setPosition] = useState<Position>('left');
 
-  const isDisabled = src === '';
+  const [isUploading, setIsUploading] = useState(false);
+
+  const isDisabled = src === '' || isUploading;
 
   const handleShowCaptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setShowCaption(e.target.checked);
@@ -78,17 +81,16 @@ export function InsertInlineImageDialog({
     setPosition(e.target.value as Position);
   };
 
-  const loadImage = (files: FileList | null) => {
-    const reader = new FileReader();
-    reader.onload = function () {
-      if (typeof reader.result === 'string') {
-        setSrc(reader.result);
-      }
-      return '';
-    };
-    if (files !== null) {
-      reader.readAsDataURL(files[0]);
+  const loadImage = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    setIsUploading(true);
+    const { url, error } = await uploadPostImage(files[0]);
+    if (url) {
+      setSrc(url);
+    } else {
+      console.error('Image upload failed:', error);
     }
+    setIsUploading(false);
   };
 
   useEffect(() => {

--- a/src/components/ui/ReadOnlyLexicalViewerClient.tsx
+++ b/src/components/ui/ReadOnlyLexicalViewerClient.tsx
@@ -98,10 +98,6 @@ const MaxLengthPlugin = dynamic(
     ),
   { ssr: false },
 );
-const ExcalidrawPlugin = dynamic(
-  () => import('@/components/lexical-playground/plugins/ExcalidrawPlugin'),
-  { ssr: false },
-);
 const ComponentPickerPlugin = dynamic(
   () => import('@/components/lexical-playground/plugins/ComponentPickerPlugin'),
   { ssr: false },

--- a/src/lib/uploadPostImage.ts
+++ b/src/lib/uploadPostImage.ts
@@ -1,0 +1,21 @@
+import { createSupabaseBrowserClient } from './supabase/browser';
+
+export async function uploadPostImage(file: File): Promise<{ url: string | null; error?: string }> {
+  const supabase = createSupabaseBrowserClient();
+  const { data: userData } = await supabase.auth.getUser();
+  const userId = userData.user?.id || 'anon';
+  const ext = file.name.split('.').pop() || 'png';
+  const filePath = `user-${userId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+
+  const { error } = await supabase.storage
+    .from('post-images')
+    .upload(filePath, file, { cacheControl: '3600', contentType: file.type, upsert: false });
+
+  if (error) {
+    console.error('Error uploading image:', error.message);
+    return { url: null, error: error.message };
+  }
+
+  const { data } = supabase.storage.from('post-images').getPublicUrl(filePath);
+  return { url: data.publicUrl, error: undefined };
+}


### PR DESCRIPTION
## Summary
- allow uploading post images to Supabase storage
- show images in the editor using the uploaded URLs
- remove unused Excalidraw plugin import

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: TS errors in lexical files)*