### PR TITLE
Fix subset of lint errors

### DIFF
--- a/src/lib/data/bookmarks.ts
+++ b/src/lib/data/bookmarks.ts
@@ -5,7 +5,7 @@ interface ToggleBookmarkArgs {
   userId: string;
 }
 
-export async function toggleBookmark({ postId, userId }: ToggleBookmarkArgs) {
+export async function toggleBookmark({ postId, userId }: ToggleBookmarkArgs): Promise<{ removed?: boolean; added?: boolean; data?: unknown }> {
   const supabase = await createServerSupabaseClient();
   // Check if bookmark exists
   const { data: existing } = await supabase
@@ -36,7 +36,7 @@ export async function toggleBookmark({ postId, userId }: ToggleBookmarkArgs) {
   }
 }
 
-export async function getBookmarksForUser(userId: string) {
+export async function getBookmarksForUser(userId: string): Promise<unknown[]> {
   const supabase = await createServerSupabaseClient();
   const { data, error } = await supabase
     .from("post_bookmarks")

--- a/src/lib/data/posts.ts
+++ b/src/lib/data/posts.ts
@@ -1,6 +1,6 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 
-export async function getPostById(postId: string) {
+export async function getPostById(postId: string): Promise<unknown> {
   const supabase = await createServerSupabaseClient();
   const { data, error } = await supabase
     .from("posts")
@@ -17,7 +17,7 @@ export async function getPostById(postId: string) {
   return data;
 }
 
-export async function getPostBySlug(slug: string) {
+export async function getPostBySlug(slug: string): Promise<unknown> {
   const supabase = await createServerSupabaseClient();
   const { data, error } = await supabase
     .from("posts")
@@ -34,7 +34,7 @@ export async function getPostBySlug(slug: string) {
   return data;
 }
 
-export async function getPostStats(postId: string) {
+export async function getPostStats(postId: string): Promise<unknown> {
   const supabase = await createServerSupabaseClient();
   const { data, error } = await supabase
     .from("posts")
@@ -45,7 +45,7 @@ export async function getPostStats(postId: string) {
   return data;
 }
 
-export async function getPostStatsBySlug(slug: string) {
+export async function getPostStatsBySlug(slug: string): Promise<unknown> {
   const supabase = await createServerSupabaseClient();
   const { data, error } = await supabase
     .from("posts")

--- a/src/lib/data/reactions.ts
+++ b/src/lib/data/reactions.ts
@@ -16,7 +16,7 @@ export async function togglePostReaction({
   postId,
   userId,
   type,
-}: TogglePostReactionArgs) {
+}: TogglePostReactionArgs): Promise<unknown> {
   const supabase = await createServerSupabaseClient();
   const { data, error } = await supabase
     .from("post_reactions")
@@ -33,7 +33,7 @@ export async function toggleCommentReaction({
   commentId,
   userId,
   reaction_type,
-}: ToggleCommentReactionArgs) {
+}: ToggleCommentReactionArgs): Promise<unknown> {
   const supabase = await createServerSupabaseClient();
   const { data, error } = await supabase
     .from("comment_reactions")
@@ -52,7 +52,7 @@ export async function toggleCommentReaction({
   return data;
 }
 
-export async function getReactionsForPost(postId: string) {
+export async function getReactionsForPost(postId: string): Promise<unknown[]> {
   const supabase = await createServerSupabaseClient();
   const { data, error } = await supabase
     .from("post_reactions")

--- a/src/types/@components-ui-mode-toggle.d.ts
+++ b/src/types/@components-ui-mode-toggle.d.ts
@@ -1,7 +1,8 @@
  
  
 declare module "@/components/ui/mode-toggle" {
-  export const ModeToggle: any;
-  const content: any;
+  import type { FC } from "react";
+  export const ModeToggle: FC;
+  const content: FC;
   export = content;
 }

--- a/src/types/@radix-ui__react-dropdown-menu.d.ts
+++ b/src/types/@radix-ui__react-dropdown-menu.d.ts
@@ -1,5 +1,5 @@
  
 declare module "@radix-ui/react-dropdown-menu" {
-  const content: any;
-  export = content;
+  import type * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+  export = DropdownMenu;
 }

--- a/src/types/@radix-ui__react-select.d.ts
+++ b/src/types/@radix-ui__react-select.d.ts
@@ -1,5 +1,5 @@
  
 declare module "@radix-ui/react-select" {
-  const content: any;
-  export = content;
+  import type * as Select from "@radix-ui/react-select";
+  export = Select;
 }

--- a/src/types/@radix-ui__react-tooltip.d.ts
+++ b/src/types/@radix-ui__react-tooltip.d.ts
@@ -1,6 +1,6 @@
  
  
 declare module "@radix-ui/react-tooltip" {
-  const content: any;
-  export = content;
+  import type * as Tooltip from "@radix-ui/react-tooltip";
+  export = Tooltip;
 }

--- a/src/types/comments-v2.ts
+++ b/src/types/comments-v2.ts
@@ -22,7 +22,7 @@ export interface Comment {
   parent_id: string | null;
   thread_depth: number;
   reply_count: number;
-  metadata: Record<string, any>;
+  metadata: Record<string, unknown>;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;

--- a/src/types/next-link.d.ts
+++ b/src/types/next-link.d.ts
@@ -1,6 +1,6 @@
  
  
 declare module "next/link" {
-  const content: any;
-  export = content;
+  import type * as NextLink from "next/link";
+  export = NextLink;
 }


### PR DESCRIPTION
## Summary
- add explicit return types to server data functions
- refine comment metadata type to avoid `any`
- provide types for module declarations

## Testing
- `pnpm test`
- `npx next lint --file src/lib/data/bookmarks.ts`
- `npx next lint --file src/lib/data/posts.ts`
- `npx next lint --file src/lib/data/reactions.ts`
- `npx next lint --file src/types/@components-ui-mode-toggle.d.ts`
- `npx next lint --file src/types/@radix-ui__react-dropdown-menu.d.ts`
- `npx next lint --file src/types/@radix-ui__react-select.d.ts`
- `npx next lint --file src/types/@radix-ui__react-tooltip.d.ts`
- `npx next lint --file src/types/comments-v2.ts`
- `npx next lint --file src/types/next-link.d.ts`


------
https://chatgpt.com/codex/tasks/task_e_6848aa9c577883239605c64bc8434e5d